### PR TITLE
Fix GitHub Actions workflow to use build:deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,7 +50,7 @@ jobs:
         run: npm run security:check
 
       - name: 🏗️ Test build
-        run: npm run build
+        run: npm run build:deploy
 
       - name: 📈 Upload test coverage
         uses: actions/upload-artifact@v4
@@ -84,11 +84,11 @@ jobs:
       - name: 📋 Install dependencies
         run: npm install
 
-      - name: 🏗️ Build React portfolio
-        run: npm run build
+      - name: 🏗️ Build and prepare deployment assets
+        run: npm run build:deploy
 
       - name: 🧹 Remove _redirects file (if exists)
-        run: rm -f dist/_redirects
+        run: rm -f build/_redirects
 
       - name: 🚀 Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
- Update deploy workflow to run npm run build:deploy instead of npm run build
- Update quality checks to also use build:deploy for consistency
- Fix _redirects file path to use build directory instead of dist
- Ensures build directory exists before Wrangler deployment
- Fixes ENOENT error when Wrangler tries to access non-existent build directory