### PR TITLE
feat(legal): rewrite privacy, add T&C, hide chat on legal pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,9 +321,16 @@
     </div>
 
     <script>
+      // Chat is hidden on legal/static pages — see Layout in src/App.jsx
+      window.__isChatHiddenRoute = () => {
+        const p = window.location.pathname;
+        return p === '/privacy' || p === '/terms';
+      };
+
       // Show chat button and handle dynamic behavior
       window.addEventListener('load', () => {
         setTimeout(() => {
+          if (window.__isChatHiddenRoute()) return;
           const chatButton = document.getElementById('openChat');
           const chatButtonText = document.getElementById('chatButtonText');
           const chatButtonIcon = document.getElementById('chatButtonIcon');
@@ -358,6 +365,7 @@
           let isExpanded = false;
 
           const handleScroll = () => {
+            if (window.__isChatHiddenRoute()) return;
             const scrollY = window.scrollY;
             const isMobile = window.innerWidth <= 768;
 
@@ -528,6 +536,7 @@
 
       openChatBtn.onclick = function (e) {
         e.stopPropagation();
+        if (window.__isChatHiddenRoute && window.__isChatHiddenRoute()) return;
         openChat();
       };
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -38,7 +38,13 @@
   </url>
   <url>
     <loc>https://www.aswincloud.com/privacy</loc>
-    <lastmod>2024-12-19</lastmod>
+    <lastmod>2026-05-26</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://www.aswincloud.com/terms</loc>
+    <lastmod>2026-05-26</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,11 +6,12 @@
  */
 
 import React, { useEffect } from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, useLocation } from 'react-router-dom';
 import Navigation from './components/Navigation.jsx';
 import SearchModal from './components/SearchModal.jsx';
 import NotFound from './components/NotFound.jsx';
 import PrivacyPolicy from './components/PrivacyPolicy.jsx';
+import TermsConditions from './components/TermsConditions.jsx';
 import {
   HeroSection,
   AboutSection,
@@ -69,7 +70,31 @@ const HomePage = () => {
   );
 };
 
+const CHAT_ELEMENT_IDS = ['openChat', 'chatModal', 'chatModalOverlay'];
+const LEGAL_ROUTES = ['/privacy', '/terms'];
+
+const useChatVisibility = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    const hide = LEGAL_ROUTES.includes(pathname);
+    CHAT_ELEMENT_IDS.forEach(id => {
+      const el = document.getElementById(id);
+      if (!el) return;
+      if (hide) {
+        el.dataset.prevDisplay = el.style.display;
+        el.style.display = 'none';
+      } else if ('prevDisplay' in el.dataset) {
+        el.style.display = el.dataset.prevDisplay;
+        delete el.dataset.prevDisplay;
+      }
+    });
+  }, [pathname]);
+};
+
 const Layout = ({ children }) => {
+  useChatVisibility();
+
   return (
     <div className='min-h-screen bg-white text-gray-900'>
       <ScrollProgress />
@@ -108,6 +133,14 @@ const App = () => {
                 element={
                   <ErrorBoundary level='page' fallbackComponent='Privacy Policy'>
                     <PrivacyPolicy />
+                  </ErrorBoundary>
+                }
+              />
+              <Route
+                path='/terms'
+                element={
+                  <ErrorBoundary level='page' fallbackComponent='Terms & Conditions'>
+                    <TermsConditions />
                   </ErrorBoundary>
                 }
               />

--- a/src/components/PrivacyPolicy.jsx
+++ b/src/components/PrivacyPolicy.jsx
@@ -6,45 +6,218 @@
  */
 
 import React from 'react';
+import { Link } from 'react-router-dom';
+
+const Section = ({ title, children }) => (
+  <section className='mt-8'>
+    <h2 className='text-xl font-semibold mb-3 text-gray-800'>{title}</h2>
+    <div className='text-gray-700 leading-relaxed space-y-3'>{children}</div>
+  </section>
+);
 
 const PrivacyPolicy = () => (
   <div className='min-h-screen bg-gray-50 py-20'>
     <div className='container-custom max-w-3xl mx-auto bg-white rounded-xl shadow-lg p-8'>
-      <h1 className='text-3xl font-bold mb-6 text-gray-900'>Privacy Policy</h1>
-      <p className='mb-4 text-gray-700'>
-        Your privacy is important to me. This Privacy Policy explains how your personal information
-        is collected, used, and protected when you use this website.
-      </p>
-      <h2 className='text-xl font-semibold mt-6 mb-2 text-gray-800'>Information Collected</h2>
-      <ul className='list-disc pl-6 mb-4 text-gray-700'>
-        <li>Contact form submissions (name, email, message)</li>
-        <li>Basic analytics data (page views, device/browser info)</li>
-      </ul>
-      <h2 className='text-xl font-semibold mt-6 mb-2 text-gray-800'>How Information is Used</h2>
-      <ul className='list-disc pl-6 mb-4 text-gray-700'>
-        <li>To respond to your inquiries via the contact form</li>
-        <li>To improve the website and user experience</li>
-        <li>To monitor and analyze website traffic</li>
-      </ul>
-      <h2 className='text-xl font-semibold mt-6 mb-2 text-gray-800'>Data Protection</h2>
-      <ul className='list-disc pl-6 mb-4 text-gray-700'>
-        <li>Your data is not sold or shared with third parties</li>
-        <li>Reasonable security measures are in place to protect your information</li>
-      </ul>
-      <h2 className='text-xl font-semibold mt-6 mb-2 text-gray-800'>Third-Party Services</h2>
-      <ul className='list-disc pl-6 mb-4 text-gray-700'>
-        <li>Email delivery is handled by Resend API</li>
-        <li>Analytics may be provided by Google Analytics</li>
-      </ul>
-      <h2 className='text-xl font-semibold mt-6 mb-2 text-gray-800'>Contact</h2>
-      <p className='mb-4 text-gray-700'>
-        If you have any questions about this Privacy Policy, please contact me at{' '}
+      <h1 className='text-3xl font-bold mb-2 text-gray-900'>Privacy Policy</h1>
+      <p className='text-sm text-gray-500 mb-6'>Last updated: May 26, 2026</p>
+
+      <p className='text-gray-700 leading-relaxed'>
+        This page explains what information is collected when you visit{' '}
+        <span className='font-medium'>aswincloud.com</span>, how it is used, and the choices you
+        have. This is a personal portfolio site operated by Aswin (&quot;I&quot;, &quot;me&quot;).
+        If anything here is unclear, email{' '}
         <a href='mailto:contact@aswincloud.com' className='text-secondary-600 underline'>
           contact@aswincloud.com
         </a>
         .
       </p>
-      <p className='text-gray-500 text-sm mt-8'>Last updated: July 6, 2025</p>
+
+      <Section title='Information collected'>
+        <p>
+          <span className='font-medium'>Contact form.</span> When you submit the contact form, the
+          name, email address, and message you provide are sent to me by email. These fields are
+          required for me to respond.
+        </p>
+        <p>
+          <span className='font-medium'>Analytics.</span> The site uses Google Analytics (GA4) to
+          measure traffic. This collects standard analytics signals such as pages viewed, referring
+          URL, approximate location (country/region), device and browser type, and an anonymised
+          identifier. IP addresses are not stored in a personally identifiable form.
+        </p>
+        <p>
+          <span className='font-medium'>Hosting logs.</span> The site is served via Cloudflare. As
+          part of normal operation, Cloudflare processes request metadata (IP address, user agent,
+          timestamp) for delivery, caching, and security. I do not access or retain these logs
+          beyond what Cloudflare provides.
+        </p>
+        <p>
+          <span className='font-medium'>Local browser storage.</span> The site may write a small
+          diagnostic record (key <code className='font-mono text-sm'>portfolio_errors</code>) to
+          your browser&apos;s <code className='font-mono text-sm'>localStorage</code> if a runtime
+          error occurs. This stays on your device and is not transmitted anywhere.
+        </p>
+      </Section>
+
+      <Section title='How the information is used'>
+        <ul className='list-disc pl-6 space-y-1'>
+          <li>To reply to messages sent through the contact form.</li>
+          <li>
+            To understand which pages and projects are read, so I can improve the content and
+            structure of the site.
+          </li>
+          <li>To diagnose and fix bugs or performance issues.</li>
+          <li>
+            To detect and block abusive traffic (spam submissions, automated scraping, denial of
+            service).
+          </li>
+        </ul>
+        <p>
+          Your information is not sold, rented, or shared for advertising. I do not run ads on this
+          site and do not build profiles for marketing.
+        </p>
+      </Section>
+
+      <Section title='Third-party services'>
+        <p>The site relies on a small number of processors:</p>
+        <ul className='list-disc pl-6 space-y-1'>
+          <li>
+            <span className='font-medium'>Cloudflare</span> &mdash; hosting, DNS, and edge delivery
+            (
+            <a
+              href='https://www.cloudflare.com/privacypolicy/'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='text-secondary-600 underline'
+            >
+              privacy policy
+            </a>
+            ).
+          </li>
+          <li>
+            <span className='font-medium'>Resend</span> &mdash; transactional email delivery for
+            contact-form submissions (
+            <a
+              href='https://resend.com/legal/privacy-policy'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='text-secondary-600 underline'
+            >
+              privacy policy
+            </a>
+            ).
+          </li>
+          <li>
+            <span className='font-medium'>Google Analytics</span> &mdash; aggregate traffic
+            analytics (
+            <a
+              href='https://policies.google.com/privacy'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='text-secondary-600 underline'
+            >
+              privacy policy
+            </a>
+            ).
+          </li>
+          <li>
+            <span className='font-medium'>Google Fonts</span> &mdash; web font delivery. Fonts are
+            fetched directly from Google&apos;s CDN when you load the site.
+          </li>
+        </ul>
+      </Section>
+
+      <Section title='Cookies and similar technologies'>
+        <p>
+          Google Analytics sets cookies (typically <code className='font-mono text-sm'>_ga</code>{' '}
+          and <code className='font-mono text-sm'>_ga_*</code>) used to distinguish unique visitors
+          and sessions. No advertising or cross-site tracking cookies are set by this site.
+        </p>
+        <p>
+          You can block analytics cookies via your browser&apos;s settings, a tracking-prevention
+          extension, or by enabling &quot;Do Not Track&quot;. The rest of the site works normally
+          without them.
+        </p>
+      </Section>
+
+      <Section title='Data retention'>
+        <ul className='list-disc pl-6 space-y-1'>
+          <li>
+            <span className='font-medium'>Contact form messages</span> are retained in my inbox
+            until I no longer need them to maintain the conversation. You can ask me to delete a
+            specific thread at any time.
+          </li>
+          <li>
+            <span className='font-medium'>Analytics data</span> is retained according to the default
+            Google Analytics retention window (currently 14 months for event-level data).
+          </li>
+          <li>
+            <span className='font-medium'>Local diagnostic data</span> in your browser persists
+            until you clear site data, which you can do at any time via your browser settings.
+          </li>
+        </ul>
+      </Section>
+
+      <Section title='Your rights'>
+        <p>
+          Depending on where you live, you may have rights under laws such as the GDPR, the UK GDPR,
+          or India&apos;s DPDP Act &mdash; including the right to access, correct, or delete
+          information that relates to you, and to object to certain processing.
+        </p>
+        <p>
+          To exercise any of these rights, email{' '}
+          <a href='mailto:contact@aswincloud.com' className='text-secondary-600 underline'>
+            contact@aswincloud.com
+          </a>
+          . I respond to requests within a reasonable time, generally under 30 days.
+        </p>
+      </Section>
+
+      <Section title='Children'>
+        <p>
+          This site is not directed at children under 13, and information about children is not
+          knowingly collected. If you believe a child has submitted information through the contact
+          form, email me and I will delete it.
+        </p>
+      </Section>
+
+      <Section title='Security'>
+        <p>
+          Reasonable technical safeguards are in place &mdash; HTTPS everywhere, secret keys held
+          server-side, and minimum-necessary data collection. No website can guarantee absolute
+          security; if you suspect a vulnerability, please report it to{' '}
+          <a href='mailto:contact@aswincloud.com' className='text-secondary-600 underline'>
+            contact@aswincloud.com
+          </a>
+          .
+        </p>
+      </Section>
+
+      <Section title='Changes to this policy'>
+        <p>
+          This policy may be updated occasionally to reflect changes in the site, the tools it uses,
+          or applicable law. The &quot;Last updated&quot; date at the top of the page will always
+          reflect the most recent revision. Material changes will be highlighted on the home page
+          where reasonable.
+        </p>
+      </Section>
+
+      <Section title='Contact'>
+        <p>
+          Questions, deletion requests, or anything else &mdash;{' '}
+          <a href='mailto:contact@aswincloud.com' className='text-secondary-600 underline'>
+            contact@aswincloud.com
+          </a>
+          .
+        </p>
+      </Section>
+
+      <p className='mt-10 text-sm text-gray-500'>
+        See also:{' '}
+        <Link to='/terms' className='text-secondary-600 underline'>
+          Terms &amp; Conditions
+        </Link>
+        .
+      </p>
     </div>
   </div>
 );

--- a/src/components/TermsConditions.jsx
+++ b/src/components/TermsConditions.jsx
@@ -1,0 +1,187 @@
+/**
+ * @file TermsConditions.jsx
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Terms & Conditions page covering site use, IP, contact form, and disclaimers
+ */
+
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const Section = ({ title, children }) => (
+  <section className='mt-8'>
+    <h2 className='text-xl font-semibold mb-3 text-gray-800'>{title}</h2>
+    <div className='text-gray-700 leading-relaxed space-y-3'>{children}</div>
+  </section>
+);
+
+const TermsConditions = () => (
+  <div className='min-h-screen bg-gray-50 py-20'>
+    <div className='container-custom max-w-3xl mx-auto bg-white rounded-xl shadow-lg p-8'>
+      <h1 className='text-3xl font-bold mb-2 text-gray-900'>Terms &amp; Conditions</h1>
+      <p className='text-sm text-gray-500 mb-6'>Last updated: May 26, 2026</p>
+
+      <p className='text-gray-700 leading-relaxed'>
+        These terms govern your use of <span className='font-medium'>aswincloud.com</span> (the
+        &quot;site&quot;), a personal portfolio operated by Aswin (&quot;I&quot;, &quot;me&quot;).
+        By using the site you agree to the terms below. If you do not agree, please do not use the
+        site.
+      </p>
+
+      <Section title='1. Acceptance of terms'>
+        <p>
+          Accessing or browsing the site, submitting the contact form, or interacting with any
+          feature provided here constitutes acceptance of these terms and the{' '}
+          <Link to='/privacy' className='text-secondary-600 underline'>
+            Privacy Policy
+          </Link>
+          . These terms may be updated from time to time; the &quot;Last updated&quot; date above
+          will always reflect the most recent revision. Continued use of the site after a change
+          means you accept the revised terms.
+        </p>
+      </Section>
+
+      <Section title='2. Intellectual property'>
+        <p>
+          Unless stated otherwise, the written content, design, and images on this site are © Aswin
+          and are made available for personal reading and reference only. You may link to pages on
+          this site freely.
+        </p>
+        <p>
+          You may not copy, reproduce, redistribute, or repurpose the content for commercial use,
+          for training machine-learning models, or as part of another portfolio or résumé, without
+          prior written permission.
+        </p>
+        <p>
+          The source code for this site is published on{' '}
+          <a
+            href='https://github.com/Aswincloud/portfolio'
+            target='_blank'
+            rel='noopener noreferrer'
+            className='text-secondary-600 underline'
+          >
+            GitHub
+          </a>{' '}
+          and is licensed under the terms stated in that repository. Third-party libraries used by
+          the site retain their own licenses.
+        </p>
+        <p>
+          Logos and company names referenced on the site (e.g.{' '}
+          <span className='font-medium'>MulticoreWare</span>,{' '}
+          <span className='font-medium'>Lenovo</span>,{' '}
+          <span className='font-medium'>Tenstorrent</span>) are the property of their respective
+          owners and are used here for identification only.
+        </p>
+      </Section>
+
+      <Section title='3. Use of the contact form'>
+        <p>By submitting a message through the contact form you confirm that:</p>
+        <ul className='list-disc pl-6 space-y-1'>
+          <li>The information you provide (name, email, message) is accurate.</li>
+          <li>You are over the age of 13.</li>
+          <li>
+            You are not submitting spam, marketing solicitations, malware, phishing attempts, or
+            content that is unlawful, threatening, defamatory, or infringes another party&apos;s
+            rights.
+          </li>
+        </ul>
+        <p>
+          Submissions are forwarded to me by email via Resend; see the{' '}
+          <Link to='/privacy' className='text-secondary-600 underline'>
+            Privacy Policy
+          </Link>{' '}
+          for how that data is handled. I may decline to respond to any message, and I may block
+          senders who abuse the form.
+        </p>
+      </Section>
+
+      <Section title='4. Third-party links and services'>
+        <p>
+          The site links to external services, projects, and articles &mdash; for example GitHub,
+          LinkedIn, the TTNN Eltwise Performance dashboard, and Telegram bots. I do not control
+          these third parties and I am not responsible for their content, terms, or privacy
+          practices. Visiting them is at your own discretion.
+        </p>
+      </Section>
+
+      <Section title='5. Accuracy of information'>
+        <p>
+          The site describes projects, experience, and technical work in good faith. Specifics such
+          as performance numbers, dates, and project status can change; I do not warrant that every
+          detail is current or error-free at every moment. If you spot a mistake, please let me know
+          at{' '}
+          <a href='mailto:contact@aswincloud.com' className='text-secondary-600 underline'>
+            contact@aswincloud.com
+          </a>
+          .
+        </p>
+      </Section>
+
+      <Section title='6. Disclaimer of warranty'>
+        <p>
+          The site and all content are provided on an &quot;as is&quot; and &quot;as available&quot;
+          basis, without warranties of any kind, express or implied &mdash; including but not
+          limited to warranties of merchantability, fitness for a particular purpose,
+          non-infringement, or uninterrupted availability. Code snippets, technical opinions, and
+          recommendations on this site are personal and do not constitute professional advice.
+        </p>
+      </Section>
+
+      <Section title='7. Limitation of liability'>
+        <p>
+          To the maximum extent permitted by law, in no event will I be liable for any indirect,
+          incidental, special, consequential, or punitive damages &mdash; including loss of profits,
+          data, or goodwill &mdash; arising from your use of, or inability to use, the site or any
+          content linked from it. My total liability for any claim related to the site is limited to
+          the greater of (a) the amount you paid me to use the site (typically zero) or (b) INR
+          1,000.
+        </p>
+      </Section>
+
+      <Section title='8. Indemnity'>
+        <p>
+          You agree to indemnify and hold me harmless from any claims, damages, or expenses
+          (including reasonable legal fees) arising from your misuse of the site, your violation of
+          these terms, or your infringement of any third-party right.
+        </p>
+      </Section>
+
+      <Section title='9. Termination'>
+        <p>
+          I may suspend or remove access to the site, or any feature on it, at any time and without
+          prior notice. Sections that by their nature should survive termination (intellectual
+          property, disclaimers, limitation of liability, indemnity, governing law) will continue to
+          apply.
+        </p>
+      </Section>
+
+      <Section title='10. Governing law'>
+        <p>
+          These terms are governed by the laws of India. Any dispute arising out of or in connection
+          with the site or these terms will be subject to the exclusive jurisdiction of the courts
+          of Pondicherry, India.
+        </p>
+      </Section>
+
+      <Section title='11. Contact'>
+        <p>
+          For questions about these terms, email{' '}
+          <a href='mailto:contact@aswincloud.com' className='text-secondary-600 underline'>
+            contact@aswincloud.com
+          </a>
+          .
+        </p>
+      </Section>
+
+      <p className='mt-10 text-sm text-gray-500'>
+        See also:{' '}
+        <Link to='/privacy' className='text-secondary-600 underline'>
+          Privacy Policy
+        </Link>
+        .
+      </p>
+    </div>
+  </div>
+);
+
+export default TermsConditions;

--- a/src/components/sections/Footer.jsx
+++ b/src/components/sections/Footer.jsx
@@ -26,6 +26,12 @@ const Footer = () => {
                 Privacy Policy
               </a>
               <a
+                href='/terms'
+                className='text-gray-500 hover:text-secondary-600 transition-colors duration-200'
+              >
+                Terms &amp; Conditions
+              </a>
+              <a
                 href='https://github.com/Aswincloud/portfolio'
                 target='_blank'
                 rel='noopener noreferrer'


### PR DESCRIPTION
## Summary

- **Privacy Policy** rewritten to reflect the site's actual data flows: contact form via Resend, Google Analytics 4 with cookie names, Cloudflare hosting logs, and the `portfolio_errors` localStorage diagnostic key. Adds retention windows, user rights (GDPR / UK GDPR / DPDP), cookies, security, and a children policy.
- **New Terms & Conditions** page at `/terms` covering acceptance, IP (including ML-training opt-out), contact form rules, third-party links, warranty disclaimer, liability cap (INR 1,000), indemnity, termination, and governing law (Pondicherry, India).
- **Live chat hidden** on `/privacy` and `/terms` — `Layout` uses `useLocation` to toggle the chat elements, with matching pathname guards in `index.html` so the inline scroll handler stops rewriting `cssText` on those routes.
- T&C linked from the footer; both pages added to `sitemap.xml` with refreshed `lastmod`.

## Test plan

- [ ] CF preview: `/` still loads, chat button visible and behaves normally on scroll
- [ ] CF preview: `/privacy` renders new content, chat button + modal absent
- [ ] CF preview: `/terms` renders new content, chat button + modal absent
- [ ] SPA navigation `/` → `/privacy` → `/` correctly hides then restores the chat button
- [ ] Footer link to Terms & Conditions works
- [ ] Cross-links between `/privacy` and `/terms` work
- [ ] Mobile width (375px) reads cleanly on both pages
- [ ] No console errors on either page

🤖 Generated with [Claude Code](https://claude.com/claude-code)