### PR TITLE
chore(deps): framer-motion 10 → motion 12 (motion/react, smaller bundle)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "^0.4.0",
-        "framer-motion": "^10.16.0",
         "lucide-react": "^0.294.0",
+        "motion": "^12.40.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-intersection-observer": "^9.5.2",
@@ -530,6 +530,7 @@
       "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "0.7.4"
       }
@@ -539,7 +540,8 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.5",
@@ -4019,21 +4021,23 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.18.0.tgz",
-      "integrity": "sha512-oGlDh1Q1XqYPksuTD/usb0I70hq95OUzmL9+6Zd+Hs4XV0oaISBa/UUMSjYiq6m8EUF32132mOJ8xVZS+I0S6w==",
-      "license": "MIT",
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz",
+      "integrity": "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==",
       "dependencies": {
+        "motion-dom": "^12.40.0",
+        "motion-utils": "^12.39.0",
         "tslib": "^2.4.0"
       },
-      "optionalDependencies": {
-        "@emotion/is-prop-valid": "^0.8.2"
-      },
       "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
         "react": {
           "optional": true
         },
@@ -5693,6 +5697,44 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.40.0.tgz",
+      "integrity": "sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA==",
+      "dependencies": {
+        "framer-motion": "^12.40.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.40.0.tgz",
+      "integrity": "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="
     },
     "node_modules/mrmime": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@cloudflare/kv-asset-handler": "^0.4.0",
-    "framer-motion": "^10.16.0",
+    "motion": "^12.40.0",
     "lucide-react": "^0.294.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.jsx
@@ -7,7 +7,7 @@
 
 /* eslint-disable no-undef */
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion } from 'motion/react';
 import {
   RefreshCw,
   AlertTriangle,

--- a/src/components/ErrorBoundary/ErrorDevTools.jsx
+++ b/src/components/ErrorBoundary/ErrorDevTools.jsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence } from 'motion/react';
 import {
   Bug,
   X,

--- a/src/components/ErrorBoundary/SectionErrorBoundary.jsx
+++ b/src/components/ErrorBoundary/SectionErrorBoundary.jsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion } from 'motion/react';
 import { AlertTriangle, RefreshCw, SkipForward } from 'lucide-react';
 
 // Section Error Fallback Component

--- a/src/components/ExperienceEntry.jsx
+++ b/src/components/ExperienceEntry.jsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion } from 'motion/react';
 import { MapPin, Calendar, Building, Zap, Code, Cpu } from 'lucide-react';
 import PropTypes from 'prop-types';
 import { use3DTilt, tiltPresets } from '../hooks/use3DTilt.jsx';

--- a/src/components/LoadingSpinner.jsx
+++ b/src/components/LoadingSpinner.jsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion } from 'motion/react';
 
 const LoadingSpinner = ({ size = 'md', showText = true, text = 'Loading...', className = '' }) => {
   const sizeClasses = {

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -7,7 +7,7 @@
 
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence } from 'motion/react';
 import { Menu, X, Mail, Search, Code, Home, User, Briefcase, Folder } from 'lucide-react';
 import SearchModal from './SearchModal.jsx';
 import { useThrottledScroll, usePageTransitions } from '../hooks';

--- a/src/components/NotFound.jsx
+++ b/src/components/NotFound.jsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { motion } from 'framer-motion';
+import { motion } from 'motion/react';
 import { Home, ArrowLeft, Search, AlertTriangle } from 'lucide-react';
 
 const NotFound = () => {

--- a/src/components/PageTransitions/PageTransition.jsx
+++ b/src/components/PageTransitions/PageTransition.jsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence } from 'motion/react';
 import { pageTransitionVariants, staggerVariants } from './pageTransitionVariants';
 
 // Page transition component

--- a/src/components/ScrollProgress.jsx
+++ b/src/components/ScrollProgress.jsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { motion, useScroll, useSpring, useTransform } from 'framer-motion';
+import { motion, useScroll, useSpring, useTransform } from 'motion/react';
 
 const ScrollProgress = () => {
   const { scrollYProgress } = useScroll();

--- a/src/components/SearchModal.jsx
+++ b/src/components/SearchModal.jsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useEffect, useRef } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence } from 'motion/react';
 import { Search, X, ArrowUp, ArrowDown } from 'lucide-react';
 
 const SearchModal = ({ isOpen, onClose }) => {

--- a/src/components/background/AnimatedMeshGradient.jsx
+++ b/src/components/background/AnimatedMeshGradient.jsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion } from 'motion/react';
 
 const AnimatedMeshGradient = () => {
   return (

--- a/src/components/sections/AboutSection.jsx
+++ b/src/components/sections/AboutSection.jsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion } from 'motion/react';
 import { useInView } from 'react-intersection-observer';
 import { Briefcase, Code, Cloud, Circle } from 'lucide-react';
 import { useExperienceCalculator } from '../../hooks';

--- a/src/components/sections/ContactSection.jsx
+++ b/src/components/sections/ContactSection.jsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState } from 'react';
-import { motion } from 'framer-motion';
+import { motion } from 'motion/react';
 import { useInView } from 'react-intersection-observer';
 import { Mail, MapPin, Briefcase } from 'lucide-react';
 import { useMicroInteractions } from '../../utils/microInteractions';

--- a/src/components/sections/ExperienceSection.jsx
+++ b/src/components/sections/ExperienceSection.jsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useMemo } from 'react';
-import { motion } from 'framer-motion';
+import { motion } from 'motion/react';
 import { useInView } from 'react-intersection-observer';
 import { Briefcase } from 'lucide-react';
 import { useExperienceCalculator } from '../../hooks';

--- a/src/components/sections/HeroSection.jsx
+++ b/src/components/sections/HeroSection.jsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useRef } from 'react';
-import { motion } from 'framer-motion';
+import { motion } from 'motion/react';
 import { Github, Linkedin, Mail, Briefcase, ArrowRight } from 'lucide-react';
 import { useExperienceCalculator, useThrottledScroll, useRipple } from '../../hooks';
 import { AnimatedMeshGradient } from '../background';

--- a/src/components/sections/ProjectsSection.jsx
+++ b/src/components/sections/ProjectsSection.jsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useId, useRef } from 'react';
-import { motion } from 'framer-motion';
+import { motion } from 'motion/react';
 import { useInView } from 'react-intersection-observer';
 import {
   Sparkles,

--- a/src/components/sections/SkillsSection.jsx
+++ b/src/components/sections/SkillsSection.jsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion } from 'motion/react';
 import { useInView } from 'react-intersection-observer';
 import { Code, Zap, Cpu, Cloud, Sparkles } from 'lucide-react';
 

--- a/src/components/sections/TechnologiesSection.jsx
+++ b/src/components/sections/TechnologiesSection.jsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState } from 'react';
-import { motion } from 'framer-motion';
+import { motion } from 'motion/react';
 import { useInView } from 'react-intersection-observer';
 import { Cloud, Monitor, Wifi, Server } from 'lucide-react';
 

--- a/src/hooks/usePageTransitions.js
+++ b/src/hooks/usePageTransitions.js
@@ -6,7 +6,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { useAnimation } from 'framer-motion';
+import { useAnimation } from 'motion/react';
 
 // Fast smooth scrolling function
 const smoothScrollTo = element => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,7 +19,7 @@ export default defineConfig({
         // (small) app chunk when we ship changes.
         manualChunks: {
           'react-vendor': ['react', 'react-dom', 'react-router-dom'],
-          motion: ['framer-motion'],
+          motion: ['motion'],
         },
       },
     },


### PR DESCRIPTION
Second in the upgrade sequence (after #73). Migrates `framer-motion@10` to `motion@12` and switches all 19 import sites to `motion/react`.

## Why the full rewrite, not a 1-line bump
A plain `framer-motion@12` alias bump actually **grew** the motion chunk (37 → 46 KB gz) because the alias entry pulls in more by default. Importing from `motion/react` with named imports lets the bundler tree-shake:

| | motion chunk (gz) |
|---|---|
| framer-motion 10 (baseline) | 37.13 KB |
| framer-motion 12 (alias) | 46.48 KB |
| **motion 12 (`motion/react`)** | **34.66 KB** ✅ |

## Changes
- `framer-motion` → `motion@^12.40.0` in package.json
- 19 files: `from 'framer-motion'` → `from 'motion/react'`
- `vite.config.js` manualChunks: `'framer-motion'` → `'motion'`

All APIs used (`motion`, `AnimatePresence`, `useScroll`, `useSpring`, `useTransform`, `useAnimation`) are unchanged in v12.

## Verification
- `npm run lint` ✓  `npm run test:run` 4/4 ✓  `npm run build` ✓  `npm run format:check` ✓  `npm audit` clean ✓
- Animations verified in-browser (hero fade-in, scroll reveals, nav, mobile menu) — visually identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)