### PR TITLE
chore: post-upgrade cleanup — drop unused dep, add engines, fix stale docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ A modern, responsive portfolio website built with React, Vite, and Tailwind CSS.
 
 ## 🚀 Features
 
-- **Modern React Architecture**: Built with React 18, Vite, and Tailwind CSS
+- **Modern React Architecture**: Built with React 19, Vite, and Tailwind CSS v4
 - **Responsive Design**: Optimized for all devices and screen sizes
-- **Smooth Animations**: Powered by Framer Motion
+- **Smooth Animations**: Powered by Motion (motion/react)
 - **Contact Form**: Working contact form with email notifications
 - **Professional Email**: Auto-replies and notification system
 - **SEO Optimized**: Sitemap, robots.txt, and structured data
@@ -25,7 +25,7 @@ A modern, responsive portfolio website built with React, Vite, and Tailwind CSS.
 
 ## 🛠️ Technology Stack
 
-- **Frontend**: React 18, Vite, Tailwind CSS, Framer Motion
+- **Frontend**: React 19, Vite, Tailwind CSS v4, Motion
 - **Backend**: Cloudflare Workers, MailChannels
 - **Deployment**: Cloudflare Workers with Workers Assets
 - **Version Control**: Git + GitHub

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "aswin-portfolio",
       "version": "0.0.0",
       "dependencies": {
-        "@cloudflare/kv-asset-handler": "^0.5.0",
         "lucide-react": "^0.577.0",
         "motion": "^12.40.0",
         "react": "^19.2.0",
@@ -400,14 +399,6 @@
       },
       "bin": {
         "specificity": "bin/cli.js"
-      }
-    },
-    "node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
-      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
-      "engines": {
-        "node": ">=22.0.0"
       }
     },
     "node_modules/@csstools/color-helpers": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "vite",
     "dev:host": "vite --host",
@@ -31,7 +34,6 @@
     "analyze": "npm run build:analyze && npx vite-bundle-analyzer dist"
   },
   "dependencies": {
-    "@cloudflare/kv-asset-handler": "^0.5.0",
     "lucide-react": "^0.577.0",
     "motion": "^12.40.0",
     "react": "^19.2.0",

--- a/src/components/PageTransitions/PageTransition.jsx
+++ b/src/components/PageTransitions/PageTransition.jsx
@@ -2,7 +2,7 @@
  * @file PageTransition.jsx
  * @author Aswin
  * @copyright © 2025 Aswin. All rights reserved.
- * @description Page transition system with Framer Motion for smooth animations
+ * @description Page transition system built on Motion (motion/react) for smooth animations
  */
 
 import React from 'react';

--- a/src/components/SearchModal.jsx
+++ b/src/components/SearchModal.jsx
@@ -137,7 +137,9 @@ const SearchModal = ({ isOpen, onClose }) => {
                         {index === selectedIndex && (
                           <div className='flex items-center gap-1 text-xs'>
                             <span>Press</span>
-                            <kbd className='px-2 py-1 bg-gray-100 rounded-sm text-gray-600'>Enter</kbd>
+                            <kbd className='px-2 py-1 bg-gray-100 rounded-sm text-gray-600'>
+                              Enter
+                            </kbd>
                           </div>
                         )}
                       </div>

--- a/src/utils/microInteractions.js
+++ b/src/utils/microInteractions.js
@@ -48,7 +48,7 @@ export const createRipple = (event, element) => {
   }, 600);
 };
 
-// Framer Motion variants for common micro-interactions
+// Motion (motion/react) variants for common micro-interactions
 export const microInteractionVariants = {
   // Button interactions
   buttonHover: {


### PR DESCRIPTION
Addresses the non-blocking review nits surfaced during the dependency-upgrade PRs (#73–#76).

## Changes
- **Remove `@cloudflare/kv-asset-handler`** — verified unused. The Worker serves static assets via `env.ASSETS.fetch()` (the `[assets]` binding in wrangler.toml), not the legacy `kv-asset-handler` library. It was a dead production dependency that also tightened the install to Node ≥22.
- **Add `engines: { node: ">=22" }`** — the upgraded toolchain (vitest 4, jsdom 29, lint-staged 17) requires Node 20/22+. This documents and enforces the floor, matching CI (`node-version: 22`) and the Cloudflare build.
- **Fix stale docs** after the motion 12 / React 19 / Tailwind 4 upgrades:
  - `PageTransition.jsx` header: "Framer Motion" → "Motion (motion/react)"
  - `microInteractions.js` comment: same
  - `README.md`: "React 18" → "React 19", "Framer Motion" → "Motion", "Tailwind CSS" → "Tailwind CSS v4"

No "Framer" references remain anywhere in `src/` or the README.

## Verification
`npm run lint` ✓  `npm run test:run` 4/4 ✓  `npm run build` ✓  `npm run format:check` ✓  `npm audit` clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)