### PR TITLE
ci: professional pipeline — parallel jobs, Lighthouse, bundle size, dep review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ permissions:
   contents: read
 
 jobs:
-  # ── Install once, share node_modules with downstream jobs via cache ──────────
+  # ── Warm the npm cache once so the parallel jobs below restore instead of
+  #    racing to populate it. Each job still runs its own `npm ci`. ────────────
   setup:
     name: 📦 Setup
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,52 +6,96 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel superseded runs on the same ref so the latest push wins.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
-  quality-checks:
+  # ── Install once, share node_modules with downstream jobs via cache ──────────
+  setup:
+    name: 📦 Setup
     runs-on: ubuntu-latest
-    name: 🔍 Quality Checks
-
     steps:
-      - name: 📥 Checkout code
-        uses: actions/checkout@v4
-
-      - name: 📦 Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: '22'
           cache: 'npm'
+      - run: npm ci
 
-      - name: 📋 Install dependencies
-        run: npm ci
-
-      - name: 🔍 Run ESLint
+  lint:
+    name: 🔍 Lint
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - name: ESLint
         run: npm run lint
-
-      - name: 🎨 Check Prettier formatting
+      - name: Prettier
         run: npm run format:check
-
-      - name: 📜 Check copyright headers
+      - name: Copyright headers
         run: npm run copyright:check:strict
 
-      - name: 🧪 Run tests
-        run: npm run test:run
-
-      - name: 📊 Run tests with coverage
+  test:
+    name: 🧪 Test
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - name: Tests with coverage
         run: npm run test:coverage
-
-      - name: 🔒 Run security checks
-        run: npm run security:check
-
-      - name: 🏗️ Build
-        run: npm run build
-
-      - name: 📈 Upload test coverage
+      - name: Upload coverage
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: coverage-report
           path: coverage/
           retention-days: 30
+
+  build:
+    name: 🏗️ Build
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Upload build
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+
+  security:
+    name: 🔒 Security
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - name: npm audit
+        run: npm run security:check

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,13 +13,16 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write # bundle-size + lighthouse jobs comment on the PR
 
 jobs:
   # ── Block PRs that introduce vulnerable or disallowed-license deps ───────────
   dependency-review:
     name: 🛡️ Dependency Review
     runs-on: ubuntu-latest
+    # Only this job needs to write to the PR (its failure summary comment).
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Dependency Review
@@ -47,6 +50,13 @@ jobs:
         uses: browser-actions/setup-chrome@v1
       - name: Run Lighthouse CI
         run: npx --yes @lhci/cli@0.14.x autorun
+      - name: Upload Lighthouse reports
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: lighthouse-reports
+          path: .lighthouseci/
+          retention-days: 7
 
   # ── Bundle size: report gzipped JS/CSS so bloat is visible on the PR ─────────
   bundle-size:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,85 @@
+name: PR Checks
+
+# Heavier, PR-only checks: performance, bundle size, dependency review,
+# accessibility. These run on pull requests against main, where their
+# feedback is actionable before merge.
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: pr-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write # bundle-size + lighthouse jobs comment on the PR
+
+jobs:
+  # ── Block PRs that introduce vulnerable or disallowed-license deps ───────────
+  dependency-review:
+    name: 🛡️ Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure
+
+  # ── Lighthouse: performance / accessibility / best-practices / SEO ──────────
+  # Lighthouse runs axe-core internally for its accessibility category, so this
+  # one job covers both perf and a11y — no separate (flaky) axe-cli job needed.
+  lighthouse:
+    name: 💡 Lighthouse
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v1
+      - name: Run Lighthouse CI
+        run: npx --yes @lhci/cli@0.14.x autorun
+
+  # ── Bundle size: report gzipped JS/CSS so bloat is visible on the PR ─────────
+  bundle-size:
+    name: 📦 Bundle Size
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Measure + report bundle size
+        run: |
+          {
+            echo "### 📦 Bundle size (gzipped)"
+            echo ""
+            echo "| Asset | Raw | Gzipped |"
+            echo "| --- | ---: | ---: |"
+            for f in dist/assets/*.js dist/assets/*.css; do
+              [ -f "$f" ] || continue
+              raw=$(du -k "$f" | cut -f1)
+              gz=$(gzip -c "$f" | wc -c)
+              gzkb=$(( gz / 1024 ))
+              echo "| \`$(basename "$f")\` | ${raw} KB | ${gzkb} KB |"
+            done
+            total_gz=0
+            for f in dist/assets/*.js dist/assets/*.css; do
+              [ -f "$f" ] || continue
+              g=$(gzip -c "$f" | wc -c); total_gz=$(( total_gz + g ))
+            done
+            echo ""
+            echo "**Total gzipped:** $(( total_gz / 1024 )) KB"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Aswin's Portfolio
 
+[![CI](https://github.com/Aswincloud/portfolio/actions/workflows/ci.yml/badge.svg)](https://github.com/Aswincloud/portfolio/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![React 19](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev)
+[![Tailwind CSS v4](https://img.shields.io/badge/Tailwind-v4-38BDF8?logo=tailwindcss&logoColor=white)](https://tailwindcss.com)
+[![Deployed on Cloudflare Workers](https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white)](https://www.aswincloud.com)
+
 A modern, responsive portfolio website built with React, Vite, and Tailwind CSS. Deployed on Cloudflare Workers with automated email functionality.
 
 ## 🚀 Features

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -16,7 +16,8 @@
       }
     },
     "upload": {
-      "target": "temporary-public-storage"
+      "target": "filesystem",
+      "outputDir": ".lighthouseci"
     }
   }
 }

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,22 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./dist",
+      "numberOfRuns": 1,
+      "settings": {
+        "preset": "desktop"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.9 }],
+        "categories:accessibility": ["warn", { "minScore": 0.9 }],
+        "categories:best-practices": ["warn", { "minScore": 0.9 }],
+        "categories:seo": ["warn", { "minScore": 0.9 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
Overhauls CI from a single "Quality Checks" job into a richer, more legible pipeline — the kind of green-checkmark wall that signals a well-run project.

## `ci.yml` (push + PR) — now parallel
Split the monolithic job into concurrent jobs, each with its own status check:
- 🔍 **Lint** — ESLint + Prettier + copyright headers
- 🧪 **Test** — vitest with coverage (uploaded as artifact)
- 🏗️ **Build** — production build (uploaded as artifact)
- 🔒 **Security** — `npm audit`

Plus concurrency cancellation so superseded runs stop early.

## `pr-checks.yml` (PR-only) — heavier checks
- 🛡️ **Dependency Review** — blocks PRs introducing high-severity vulnerable deps
- 💡 **Lighthouse** — performance / accessibility / best-practices / SEO on the built site (advisory `warn` ≥ 0.9). Lighthouse runs axe-core internally, so this **also covers accessibility** — no separate flaky `axe-cli` job.
- 📦 **Bundle Size** — posts a gzipped per-asset table to the run summary, so bundle bloat is visible on every PR.

## README
Added CI / MIT / React 19 / Tailwind v4 / Cloudflare Workers badges to the header.

## ⚠️ Branch protection note
This **renames the required status check** from `Quality Checks` to the new per-job names (`🔍 Lint`, `🧪 Test`, `🏗️ Build`, `🔒 Security`). After merge, update the branch-protection required-checks list to the new names, or the old required check will block future PRs as "expected but missing".

## Verification
- Both workflow YAMLs validate
- Bundle-size script tested locally against the real `dist` (renders correctly)
- Lighthouse config validated; Chrome installed via `browser-actions/setup-chrome` on the runner
- Existing gate (lint/test/build/audit) unchanged and green

🤖 Generated with [Claude Code](https://claude.com/claude-code)