### PR TITLE
perf(build): fix vendor chunk split — app chunk 95→22 KB gz

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -17,9 +17,30 @@ export default defineConfig({
         // change far less often than app code, so an isolated chunk stays in
         // the browser cache across deploys — visitors only re-download the
         // (small) app chunk when we ship changes.
-        manualChunks: {
-          'react-vendor': ['react', 'react-dom', 'react-router-dom'],
-          motion: ['motion'],
+        //
+        // A function (not the object form) is used deliberately: the object
+        // form only matched the named entry points, so transitive deps such as
+        // react-dom's `scheduler` leaked into the main chunk (~95 KB gz).
+        // Matching on the node_modules path captures the whole subtree.
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return undefined;
+          // React core + anything that must share React's module instance:
+          // react-dom pulls in scheduler; router and intersection-observer
+          // import react. Bundling them together avoids duplicate React copies.
+          if (
+            /[\\/]node_modules[\\/](react|react-dom|scheduler|react-router|react-router-dom|react-intersection-observer|@remix-run[\\/]router)[\\/]/.test(
+              id
+            )
+          ) {
+            return 'react-vendor';
+          }
+          // motion re-exports from motion-dom / motion-utils; keep the whole
+          // animation runtime in one chunk rather than the catch-all vendor.
+          if (/[\\/]node_modules[\\/](motion|framer-motion|motion-dom|motion-utils)[\\/]/.test(id))
+            return 'motion';
+          if (/[\\/]node_modules[\\/]lucide-react[\\/]/.test(id)) return 'lucide';
+          // Everything else third-party → one cacheable vendor chunk.
+          return 'vendor';
         },
       },
     },


### PR DESCRIPTION
## What

The 📦 Bundle Size check added in #78 surfaced that the main app chunk had bloated to **~95 KB gzipped** after the React 19 / Tailwind 4 upgrades. Root cause: the object-form \`manualChunks\` only matched the *named* entry points, so transitive deps leaked into \`index\`:

- **react-dom + scheduler** weren't landing in \`react-vendor\` (it was only ~12 KB gz — far too small to contain react-dom)
- **motion-dom / motion-utils** (motion's actual implementation) leaked in too

## Fix

Switch \`manualChunks\` to a **function form** that buckets by \`node_modules\` path, capturing the whole dependency subtree:

| Chunk | Contents |
| --- | --- |
| \`react-vendor\` | react, react-dom, scheduler, react-router(-dom), @remix-run/router, react-intersection-observer |
| \`motion\` | motion + motion-dom + motion-utils |
| \`lucide\` | lucide-react |

## Result (gzipped)

| Chunk | Before | After |
| --- | ---: | ---: |
| \`index\` (app) | **95 KB** | **22 KB** |
| \`react-vendor\` | 12 KB | 69 KB ✅ (now holds react-dom) |
| \`motion\` | 34 KB | 46 KB ✅ (full runtime) |
| stray \`vendor\` | — | none ✅ |

Total transfer is unchanged (same code) — but vendor code (~119 KB) now stays **browser-cached across deploys**; only the 22 KB app chunk re-downloads when app code ships. That's the actual user-facing win.

## Verification

- \`npm run lint\` clean · \`npm run test:run\` 4/4 · \`npm run build\` ✅
- Confirmed final chunk attribution via sourcemap — no misfiled deps, catch-all \`vendor\` chunk eliminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)