### PR TITLE
ci: add OpenSSF Scorecard supply-chain analysis + badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,51 @@
+name: OSSF Scorecard
+
+# Supply-chain security posture analysis (OpenSSF Scorecard). Runs weekly and
+# on changes to main / branch-protection rules, uploads findings to the
+# Security tab, and publishes results so the README badge stays live.
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '23 4 * * 1' # Mondays 04:23 UTC
+  push:
+    branches: [main]
+
+# Read-only by default; the job elevates only the scopes it needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload the SARIF result to code scanning
+      id-token: write # publish results to the OpenSSF API (powers the badge)
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publishes results to the public OpenSSF API. Required for the
+          # README badge; only runs for public repos.
+          publish_results: true
+
+      # Retain the raw SARIF as an artifact for offline inspection.
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 7
+
+      # Surface findings in the repo's Security → Code scanning tab.
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Aswin's Portfolio
 
 [![CI](https://github.com/Aswincloud/portfolio/actions/workflows/ci.yml/badge.svg)](https://github.com/Aswincloud/portfolio/actions/workflows/ci.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Aswincloud/portfolio/badge)](https://scorecard.dev/viewer/?uri=github.com/Aswincloud/portfolio)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![React 19](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev)
 [![Tailwind CSS v4](https://img.shields.io/badge/Tailwind-v4-38BDF8?logo=tailwindcss&logoColor=white)](https://tailwindcss.com)


### PR DESCRIPTION
## What

Adds the **OpenSSF Scorecard** workflow — automated supply-chain security posture analysis — plus a live README badge.

Scorecard grades the repo against ~18 checks (pinned GitHub Actions, least-privilege token permissions, branch-protection config, dependency-update tooling, code review, dangerous workflow patterns, etc.) and writes findings to the **Security → Code scanning** tab.

## How it runs

- **Weekly** (Mon 04:23 UTC) + on **push to `main`** + on **branch-protection changes**
- Uploads SARIF to code scanning (Security tab)
- `publish_results: true` → posts to the public OpenSSF API, which powers the live badge
- Raw SARIF also retained as a 7-day artifact

Permissions follow least-privilege: workflow is `read-all`; the job elevates only `security-events: write` (SARIF upload) and `id-token: write` (OIDC publish).

## Why this one

It completes the supply-chain story alongside the **CodeQL** and **Dependency Review** checks already running — without duplicating a SAST linter (which would just add overlapping findings + noise). The repo is public, so the badge and publish step are both valid.

Action pinned to `ossf/scorecard-action@v2.4.3` (latest), matching the repo's existing `@vN` tag-pin convention.

## Note

The badge will read "no data" until this lands on `main` and the first scheduled/push run publishes — that's expected; it goes live after the initial run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)