### PR TITLE
docs: add SECURITY.md vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it
+privately. **Do not open a public issue for security reports.**
+
+- **Preferred:** [Open a private security advisory](https://github.com/Aswincloud/portfolio/security/advisories/new)
+  via GitHub's "Report a vulnerability" flow.
+- **Email:** [contact@aswincloud.com](mailto:contact@aswincloud.com)
+
+Please include:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce (or a proof of concept)
+- The affected URL, file, or component
+- Any suggested remediation, if you have one
+
+## Response
+
+This is a personal portfolio project maintained by a single author. I aim to:
+
+- **Acknowledge** your report within **5 business days**
+- **Provide an assessment and remediation plan** within **14 days**
+- **Credit** reporters in the fix (unless you prefer to remain anonymous)
+
+## Scope
+
+In scope:
+
+- This repository's source code
+- The deployed site at [www.aswincloud.com](https://www.aswincloud.com) and its
+  Cloudflare Worker (`/api/*` endpoints)
+
+Out of scope:
+
+- Third-party services and dependencies (report those to their respective
+  maintainers)
+- Findings that require physical access, social engineering, or a compromised
+  end-user device
+- Volumetric denial-of-service testing
+
+## Supported Versions
+
+Only the latest deployed version (`main`) is supported. There are no long-lived
+release branches.


### PR DESCRIPTION
## What

Adds a `SECURITY.md` with a private vulnerability-disclosure policy:

- **Reporting** — GitHub private security advisory (preferred) or email
- **Response SLAs** — 5-day ack, 14-day assessment, reporter credit
- **Scope** — repo source + deployed site / Worker `/api/*`; out-of-scope items (3rd-party deps, DoS, social engineering)
- **Supported versions** — latest `main` only

## Why

Closes the only no-tradeoff gap from the OpenSSF Scorecard run (#80): **Security-Policy was 0/10**. GitHub also surfaces this file in the repo's Security tab and the "Report a vulnerability" UI.

The other low Scorecard checks (Code-Review, Branch-Protection, Packaging, Signed-Releases, Fuzzing, CII) either can't apply to a solo static-site repo or trade against the single-maintainer merge workflow — intentionally not chased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)