### PR TITLE
chore: point GitHub links to org (Aswincloud)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Visit the live portfolio: **[www.aswincloud.com](https://www.aswincloud.com)**
 ## 📱 Contact
 
 - **Email**: contact@aswincloud.com
-- **GitHub**: [github.com/Aswin-coder](https://github.com/Aswin-coder)
+- **GitHub**: [github.com/Aswincloud](https://github.com/Aswincloud)
 - **LinkedIn**: [linkedin.com/in/aswin4122001](https://www.linkedin.com/in/aswin4122001/)
 
 ## 🎯 Project Highlights
@@ -114,4 +114,4 @@ Visit the live portfolio: **[www.aswincloud.com](https://www.aswincloud.com)**
 
 ---
 
-Built with ❤️ by [Aswin](https://github.com/Aswin-coder) | Software Engineer at MulticoreWare 
+Built with ❤️ by [Aswin](https://github.com/Aswincloud) | Software Engineer at MulticoreWare

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
         "jobTitle": "Software Engineer",
         "description": "Performance engineer optimizing the software that runs on AI accelerator hardware — profiling, benchmarking, and throughput optimization. Based in Pondicherry, India.",
         "url": "https://www.aswincloud.com",
-        "sameAs": ["https://github.com/Aswin-coder", "https://www.linkedin.com/in/aswin4122001/"],
+        "sameAs": ["https://github.com/Aswincloud", "https://www.linkedin.com/in/aswin4122001/"],
         "worksFor": {
           "@type": "Organization",
           "name": "MulticoreWare"

--- a/src/components/sections/Footer.jsx
+++ b/src/components/sections/Footer.jsx
@@ -61,7 +61,7 @@ const Footer = () => {
               <Linkedin size={20} />
             </a>
             <a
-              href='https://github.com/Aswin-coder'
+              href='https://github.com/Aswincloud'
               target='_blank'
               rel='noopener noreferrer'
               className='w-10 h-10 bg-gray-800 rounded-full flex items-center justify-center hover:bg-secondary-600 transition-colors duration-200'

--- a/src/components/sections/HeroSection.jsx
+++ b/src/components/sections/HeroSection.jsx
@@ -140,7 +140,7 @@ const HeroSection = React.memo(function HeroSection() {
               transition={{ delay: 0.6 }}
             >
               {[
-                { icon: Github, href: 'https://github.com/Aswin-coder', label: 'GitHub' },
+                { icon: Github, href: 'https://github.com/Aswincloud', label: 'GitHub' },
                 {
                   icon: Linkedin,
                   href: 'https://www.linkedin.com/in/aswin4122001/',

--- a/worker.js
+++ b/worker.js
@@ -72,7 +72,7 @@ function createAutoReplyHTML(name, message) {
       </p>
       
       <div style="text-align: center; margin: 30px 0;">
-        <a href="https://github.com/Aswin-coder" 
+        <a href="https://github.com/Aswincloud"
            style="display: inline-block; background-color: #374151; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px; margin: 0 10px;">
           GitHub
         </a>
@@ -430,7 +430,7 @@ async function handleContactForm(request, env) {
       
       Your message was submitted on: ${new Date().toLocaleString()}
       
-      In the meantime, feel free to check out my work on GitHub (https://github.com/Aswin-coder) or connect with me on LinkedIn (https://www.linkedin.com/in/aswin4122001/).
+      In the meantime, feel free to check out my work on GitHub (https://github.com/Aswincloud) or connect with me on LinkedIn (https://www.linkedin.com/in/aswin4122001/).
       
       Best regards,
       Aswin


### PR DESCRIPTION
## What

Swaps every **visitor-facing** GitHub profile link from the personal account (`github.com/Aswin-coder`) to the org (`github.com/Aswincloud`).

| File | Reference |
| --- | --- |
| `HeroSection.jsx` | hero social icon |
| `Footer.jsx` | footer GitHub link |
| `index.html` | JSON-LD `sameAs` (search-engine identity) |
| `worker.js` | fallback page link + contact auto-reply email body |
| `README.md` | contact + footer credit |

## Why

The repo and the work the portfolio is about — `ttperf`, `ttnn-performance-dashboard`, `pr-review-checker`, etc. — all live under the **org**, whose profile blog is already `www.aswincloud.com`. The visible links were the last thing still pointing at the personal account. The git remote already targets `Aswincloud/portfolio`; this only changes what's shown to users.

## Safe

- Every reference was a **bare profile URL** (no `/repo` paths) — verified, nothing breaks.
- `github.com/Aswincloud` resolves HTTP 200.
- lint · test (4/4) · build · format:check all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)