### PR TITLE
security: clear code-scanning alerts — SHA-pin actions + crypto.randomUUID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
     name: 📦 Setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -33,8 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -51,8 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -60,7 +60,7 @@ jobs:
       - name: Tests with coverage
         run: npm run test:coverage
       - name: Upload coverage
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         if: always()
         with:
           name: coverage-report
@@ -72,8 +72,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -81,7 +81,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Upload build
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
           name: dist
           path: dist/
@@ -92,8 +92,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -24,9 +24,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure
@@ -38,8 +38,8 @@ jobs:
     name: 💡 Lighthouse
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
           node-version: '22'
           cache: 'npm'
@@ -47,11 +47,11 @@ jobs:
       - name: Build
         run: npm run build
       - name: Setup Chrome
-        uses: browser-actions/setup-chrome@v1
+        uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v1
       - name: Run Lighthouse CI
         run: npx --yes @lhci/cli@0.14.x autorun
       - name: Upload Lighthouse reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         if: always()
         with:
           name: lighthouse-reports
@@ -63,8 +63,8 @@ jobs:
     name: 📦 Bundle Size
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,12 +23,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -38,7 +38,7 @@ jobs:
 
       # Retain the raw SARIF as an artifact for offline inspection.
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         with:
           name: scorecard-results
           path: results.sarif
@@ -46,6 +46,6 @@ jobs:
 
       # Surface findings in the repo's Security → Code scanning tab.
       - name: Upload to code scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           sarif_file: results.sarif

--- a/src/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.jsx
@@ -99,7 +99,8 @@ class ErrorAnalytics {
   static getSessionId() {
     let sessionId = sessionStorage.getItem('portfolio_session_id');
     if (!sessionId) {
-      sessionId = Date.now().toString(36) + Math.random().toString(36).substr(2);
+      // Non-security correlation ID for grouping error reports by session.
+      sessionId = crypto.randomUUID();
       sessionStorage.setItem('portfolio_session_id', sessionId);
     }
     return sessionId;
@@ -133,7 +134,7 @@ class ErrorBoundary extends React.Component {
     return {
       hasError: true,
       error,
-      errorId: Date.now().toString(36) + Math.random().toString(36).substr(2),
+      errorId: `${Date.now().toString(36)}-${crypto.randomUUID()}`,
     };
   }
 

--- a/src/hooks/useErrorReporting.js
+++ b/src/hooks/useErrorReporting.js
@@ -81,7 +81,7 @@ export const useErrorReporting = () => {
 
       // Create standardized error object
       const errorData = {
-        id: Date.now().toString(36) + Math.random().toString(36).substr(2),
+        id: `${Date.now().toString(36)}-${crypto.randomUUID()}`,
         timestamp: new Date().toISOString(),
         message: error.message || 'Unknown error',
         stack: error.stack || '',
@@ -173,7 +173,7 @@ export const useErrorReporting = () => {
   // Track user action
   const trackUserAction = useCallback((action, context = {}) => {
     const actionData = {
-      id: Date.now().toString(36) + Math.random().toString(36).substr(2),
+      id: `${Date.now().toString(36)}-${crypto.randomUUID()}`,
       timestamp: new Date().toISOString(),
       action,
       context,
@@ -252,7 +252,8 @@ export const useErrorReporting = () => {
 const getSessionId = () => {
   let sessionId = sessionStorage.getItem('portfolio_session_id');
   if (!sessionId) {
-    sessionId = Date.now().toString(36) + Math.random().toString(36).substr(2);
+    // Non-security correlation ID for grouping error reports by session.
+    sessionId = crypto.randomUUID();
     sessionStorage.setItem('portfolio_session_id', sessionId);
   }
   return sessionId;


### PR DESCRIPTION
Clears the open alerts on the Security → Code scanning tab (30 total).

## CodeQL — `js/insecure-randomness` (2× high) → **fixed**
`getSessionId()` in `ErrorBoundary.jsx` and `useErrorReporting.js` used `Math.random()` for session IDs, which CodeQL flags as insecure in a "security context." These are non-security correlation IDs (grouping error reports), but `crypto.randomUUID()` is the correct API and clears the alerts. Also converted the 3 sibling error/action-ID generators so the next scan stays clean. No remaining `Math.random()` in `src/`.

## Scorecard — `Pinned-Dependencies` (24×) → **fixed**
Every GitHub Action pinned to a full commit SHA with a `# vTag` comment (readability + Dependabot still tracks it). Unified `scorecard.yml`'s checkout/upload-artifact from v4 → v7 to match the rest. This also raises the Scorecard `Pinned-Dependencies` score.

## Scorecard — Fuzzing / CII-Best-Practices / Code-Review / Branch-Protection (4×) → **dismissed**
Won't-fix for a solo static-site repo (dismissed separately via the Security tab with reasons): fuzzing a static React site is meaningless; CII is a separate manual badge application; Code-Review/Branch-Protection score low only because of the single-maintainer admin-merge workflow.

## Verify
lint · test (4/4) · build · format:check all green. All `uses:` refs confirmed SHA-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)