### PR TITLE
fix(projects): drop literal backticks from ttperf copy

### DIFF
--- a/src/data/projects.jsx
+++ b/src/data/projects.jsx
@@ -6,11 +6,11 @@ export const featuredProjects = [
     title: 'ttperf — TT-Metal Performance Profiler',
     domain: 'ttperf.aswincloud.com',
     description:
-      "A streamlined CLI tool for profiling Tenstorrent's TT-Metal tests and extracting device kernel performance metrics. It wraps the TT-Metal profiler with pytest, parses the result CSVs, and reports total device kernel duration — with a showcase site documenting usage. Published on PyPI: `pip install ttperf`.",
+      "A streamlined CLI tool for profiling Tenstorrent's TT-Metal tests and extracting device kernel performance metrics. It wraps the TT-Metal profiler with pytest, parses the result CSVs, and reports total device kernel duration — with a showcase site documenting usage. Published on PyPI (pip install ttperf).",
     technologies: ['Python', 'CLI', 'pytest', 'PyPI', 'Tenstorrent TT-Metal'],
     features: [
       'Automated TT-Metal profiler runs via pytest',
-      'Operation-based profiling (e.g. `ttperf add`)',
+      'Operation-based profiling (e.g. ttperf add)',
       'Automatic CSV parsing → total device kernel duration',
       'Configurable tensor shape, dtype, and layout',
       'Config-file defaults (~/.ttperf.yaml) + CI-friendly --quiet/--verbose',


### PR DESCRIPTION
## What

`project.description` and `project.features` render as **plain text** in `ProjectsSection.jsx` (no Markdown), so the backticks in the ttperf copy showed up **literally** on the live page:
- *"Published on PyPI: \`pip install ttperf\`"* → backticks visible
- *"Operation-based profiling (e.g. \`ttperf add\`)"* → backticks visible

Rephrased to parenthetical form (`pip install ttperf` → "(pip install ttperf)", etc.). The `~/.ttperf.yaml` path in the config feature line had no backticks and is unchanged.

Caught by **Copilot's review on #85** (which had already merged). No remaining backticks in `src/data/projects.jsx`.

## Verify

lint · test (4/4) · build · format:check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)