### PR TITLE
feat(ui): add Space Grotesk display font for headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap"
       rel="stylesheet"
     />
 

--- a/src/index.css
+++ b/src/index.css
@@ -57,7 +57,7 @@
   --color-warning-900: #78350f;
 
   --font-sans: Inter, system-ui, sans-serif;
-  --font-display: Cal Sans, Inter, system-ui, sans-serif;
+  --font-display: 'Space Grotesk', Inter, system-ui, sans-serif;
 
   --animate-float: float 3s ease-in-out infinite;
   --animate-fadeInUp: fadeInUp 0.8s ease-out;
@@ -251,6 +251,14 @@
     padding: 0;
     position: relative;
     scroll-behavior: smooth;
+  }
+
+  /* Headings use the display font (Space Grotesk) with slightly tighter
+     tracking, giving titles typographic character distinct from Inter body. */
+  h1,
+  h2,
+  h3 {
+    @apply font-display tracking-tight;
   }
 
   #root {


### PR DESCRIPTION
## What

`--font-display` pointed at **Cal Sans**, which was **never loaded** (0 links in `index.html`) and **never applied** (no `font-display` class anywhere) — so every heading silently fell back to Inter `font-black`, with no typographic distinction from body text.

Loads **Space Grotesk** (geometric, technical display face — fits a performance-engineering portfolio) and actually wires it up.

## How

- Add Space Grotesk to the existing Google Fonts request (one combined `css2?` call — no extra round-trip)
- Repoint `--font-display` → `'Space Grotesk', Inter, system-ui, sans-serif`
- Apply `font-display tracking-tight` to `h1/h2/h3` via a **single base-layer rule** in `index.css`, so headings stay consistent and can't drift per-section. Body text stays Inter.

## Verify

- lint · test (4/4) · format:check · build green
- Confirmed in built CSS: `h1,h2,h3 { font-family: var(--font-display) }`, Space Grotesk loaded, Cal Sans gone
- Previewed locally — headings render in Space Grotesk, body unchanged

First of a 4-part visual-polish pass (font → heading color treatment → palette → decoration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)