### PR TITLE
feat(ui): calm section headings — near-black + single accent word

### DIFF
--- a/src/components/sections/AboutSection.jsx
+++ b/src/components/sections/AboutSection.jsx
@@ -63,9 +63,7 @@ const AboutSection = React.memo(() => {
           </motion.div>
 
           <h2 className='text-4xl lg:text-5xl font-black mb-6 text-gray-900'>
-            <span className='bg-linear-to-r from-gray-900 via-blue-800 to-gray-900 bg-clip-text text-transparent'>
-              Where software meets silicon
-            </span>
+            Where software meets <span className='text-accent-600'>silicon</span>
           </h2>
           <p className='text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed'>
             Chasing microseconds on AI hardware — and running my own cloud for the fun of it
@@ -152,11 +150,7 @@ const AboutSection = React.memo(() => {
 
                 {/* Content */}
                 <div className='relative z-10'>
-                  <div
-                    className={`text-3xl font-black mb-1 bg-linear-to-r ${stat.color} bg-clip-text text-transparent`}
-                  >
-                    {stat.number}
-                  </div>
+                  <div className='text-3xl font-black mb-1 text-accent-600'>{stat.number}</div>
                   <div className='text-gray-600 font-semibold text-base'>{stat.label}</div>
                 </div>
 

--- a/src/components/sections/ContactSection.jsx
+++ b/src/components/sections/ContactSection.jsx
@@ -140,9 +140,7 @@ const ContactSection = () => {
           </motion.div>
 
           <h2 className='text-4xl lg:text-5xl font-black mb-6 text-gray-900'>
-            <span className='bg-linear-to-r from-green-600 via-blue-600 to-green-600 bg-clip-text text-transparent'>
-              Let's Work Together
-            </span>
+            Let&apos;s <span className='text-accent-600'>Work</span> Together
           </h2>
           <p className='text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed'>
             Ready to bring your ideas to life? Let's discuss your next project and create something

--- a/src/components/sections/ExperienceSection.jsx
+++ b/src/components/sections/ExperienceSection.jsx
@@ -45,11 +45,7 @@ const ExperienceSection = () => {
             </span>
           </motion.div>
 
-          <h2 className='text-4xl lg:text-5xl font-black mb-6 text-gray-900'>
-            <span className='bg-linear-to-r from-blue-600 via-indigo-600 to-blue-600 bg-clip-text text-transparent'>
-              Experience
-            </span>
-          </h2>
+          <h2 className='text-4xl lg:text-5xl font-black mb-6 text-gray-900'>Experience</h2>
           <p className='text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed'>
             Building innovative solutions and driving technological excellence across diverse
             industries

--- a/src/components/sections/ProjectsSection.jsx
+++ b/src/components/sections/ProjectsSection.jsx
@@ -233,9 +233,7 @@ const ProjectsSection = () => {
           </motion.div>
 
           <h2 className='text-5xl lg:text-6xl font-black mb-8 text-gray-900 leading-tight'>
-            <span className='bg-linear-to-r from-emerald-600 via-teal-600 to-blue-600 bg-clip-text text-transparent'>
-              Featured Projects
-            </span>
+            Featured <span className='text-accent-600'>Projects</span>
           </h2>
           <p className='text-xl text-gray-600 max-w-4xl mx-auto leading-relaxed'>
             Innovative solutions powered by machine learning and cutting-edge technology

--- a/src/components/sections/SkillsSection.jsx
+++ b/src/components/sections/SkillsSection.jsx
@@ -71,9 +71,7 @@ const SkillsSection = () => {
           </motion.div>
 
           <h2 className='text-4xl lg:text-5xl font-black mb-6 text-gray-900'>
-            <span className='bg-linear-to-r from-purple-600 via-pink-600 to-purple-600 bg-clip-text text-transparent'>
-              What I Do Best
-            </span>
+            What I Do <span className='text-accent-600'>Best</span>
           </h2>
           <p className='text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed'>
             Passionate about technologies that drive innovation and create meaningful impact

--- a/src/components/sections/TechnologiesSection.jsx
+++ b/src/components/sections/TechnologiesSection.jsx
@@ -87,9 +87,7 @@ const TechnologiesSection = () => {
           </motion.div>
 
           <h2 className='text-4xl md:text-5xl font-black mb-6 text-gray-900'>
-            <span className='bg-linear-to-r from-indigo-600 via-purple-600 to-indigo-600 bg-clip-text text-transparent'>
-              Technologies & Platforms
-            </span>
+            Technologies &amp; <span className='text-accent-600'>Platforms</span>
           </h2>
           <p className='text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed'>
             Comprehensive experience across cloud platforms, operating systems, networking, and


### PR DESCRIPTION
**Stacked on #88 (display font)** — base is `feat/display-font`, so review that first or read this diff in isolation.

## What

Every section `<h2>` was a different rainbow `bg-clip-text` gradient (green→blue, blue→indigo, purple→pink, emerald→teal→blue, indigo→purple, green→blue). Six inconsistent rainbows on white is the single biggest "2022 template" tell on the page.

Replaced all six with **near-black headings + one `accent-600` word** for emphasis:

| Section | Heading |
| --- | --- |
| About | Where software meets **silicon** |
| Experience | Experience *(plain — single word)* |
| Skills | What I Do **Best** |
| Technologies | Technologies & **Platforms** |
| Projects | Featured **Projects** |
| Contact | Let's **Work** Together |

Also unified the About **stat numbers** from three per-stat gradients to a single accent color.

## Kept deliberately

The hero `<h1>` "Aswin" **keeps its gradient** — on the dark mesh background it's the one brand moment where gradient text earns its place, and it's now the *only* gradient text on the page (intentional, not a repeated default). Respects the "don't make it too simple" constraint by keeping a single accent word per heading rather than going fully austere.

## Verify

lint · test (4/4) · format:check · build green. Previewed locally across all sections; net −18 lines (removing rainbow markup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)