### PR TITLE
feat(ui): retune palette from pink to indigo

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -12,16 +12,20 @@
   --color-primary-800: #1e293b;
   --color-primary-900: #0f172a;
 
-  --color-secondary-50: #fdf2f8;
-  --color-secondary-100: #fce7f3;
-  --color-secondary-200: #fbcfe8;
-  --color-secondary-300: #f9a8d4;
-  --color-secondary-400: #f472b6;
-  --color-secondary-500: #ec4899;
-  --color-secondary-600: #db2777;
-  --color-secondary-700: #be185d;
-  --color-secondary-800: #9d174d;
-  --color-secondary-900: #831843;
+  /* Secondary = indigo. Retuned from the original pink (#ec4899) so the whole
+     site reads as a cohesive indigo→sky cool palette instead of pink-heavy.
+     Pairs with the sky-blue accent below; updating the token reskins all
+     usages (buttons, badges, gradients) without touching className strings. */
+  --color-secondary-50: #eef2ff;
+  --color-secondary-100: #e0e7ff;
+  --color-secondary-200: #c7d2fe;
+  --color-secondary-300: #a5b4fc;
+  --color-secondary-400: #818cf8;
+  --color-secondary-500: #6366f1;
+  --color-secondary-600: #4f46e5;
+  --color-secondary-700: #4338ca;
+  --color-secondary-800: #3730a3;
+  --color-secondary-900: #312e81;
 
   --color-accent-50: #f0f9ff;
   --color-accent-100: #e0f2fe;
@@ -72,9 +76,6 @@
     from 180deg at 50% 50%,
     var(--tw-gradient-stops)
   );
-  --background-image-gradient-modern: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  --background-image-gradient-dark: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
-  --background-image-gradient-accent: linear-gradient(135deg, #ec4899 0%, #8b5cf6 100%);
 
   --backdrop-blur-xs: 2px;
 


### PR DESCRIPTION
**Stacked on #89** — base is `feat/calm-headings`.

## What

`secondary` was **pink** (#ec4899), used **76×** across buttons, badges, borders, and the ubiquitous `secondary→accent` gradients. That pink-heavy identity was the biggest "templated, not senior" signal left on the site.

Retune `--color-secondary-*` → **indigo** (Tailwind indigo scale). Since it's a design token, this reskins all 76 usages to a cohesive **indigo→sky cool palette** with **zero className changes** — fully previewable, trivially revertible.

Also deletes three **dead** `--background-image-gradient-*` tokens (modern/dark/accent) — defined but never referenced; the `accent` one still carried the old pink→violet.

## Not in this PR

The hero `AnimatedMeshGradient` still has hardcoded pink blobs (`rgba(236,72,153)`) — handled in the decoration-trim PR next, where its colors + density are the same concern.

## Verify

lint · test (4/4) · format:check · build green. Confirmed in built CSS: indigo present, pink `db2777` gone, `ec4899` only remaining in the (soon-to-change) mesh. Previewed — buttons/badges/gradients now indigo→sky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)