### PR TITLE
feat(ui): trim decoration noise + retune hero mesh to indigo

### DIFF
--- a/src/components/background/AnimatedMeshGradient.jsx
+++ b/src/components/background/AnimatedMeshGradient.jsx
@@ -12,14 +12,14 @@ const AnimatedMeshGradient = () => {
   return (
     <div className='absolute inset-0 overflow-hidden'>
       {/* Base gradient layers */}
-      <div className='absolute inset-0 bg-linear-to-br from-slate-900 via-purple-900 to-slate-900' />
-      <div className='absolute inset-0 bg-linear-to-tr from-blue-900/40 via-transparent to-pink-900/40' />
+      <div className='absolute inset-0 bg-linear-to-br from-slate-900 via-indigo-950 to-slate-900' />
+      <div className='absolute inset-0 bg-linear-to-tr from-indigo-900/40 via-transparent to-sky-900/40' />
 
       {/* Animated gradient orbs */}
       <motion.div
         className='absolute top-0 left-0 w-[500px] h-[500px] rounded-full'
         style={{
-          background: 'radial-gradient(circle, rgba(236,72,153,0.4) 0%, transparent 70%)',
+          background: 'radial-gradient(circle, rgba(99,102,241,0.4) 0%, transparent 70%)',
           filter: 'blur(80px)',
         }}
         animate={{
@@ -73,7 +73,7 @@ const AnimatedMeshGradient = () => {
       <motion.div
         className='absolute top-1/2 left-1/2 w-[550px] h-[550px] rounded-full'
         style={{
-          background: 'radial-gradient(circle, rgba(34,197,94,0.25) 0%, transparent 70%)',
+          background: 'radial-gradient(circle, rgba(14,165,233,0.25) 0%, transparent 70%)',
           filter: 'blur(85px)',
         }}
         animate={{
@@ -88,13 +88,11 @@ const AnimatedMeshGradient = () => {
         }}
       />
 
-      {/* Mesh pattern overlay */}
+      {/* Mesh pattern overlay — indigo / sky / violet, cohesive cool tones. */}
       <div className='absolute inset-0 opacity-30'>
-        <div className='absolute inset-0 bg-[radial-gradient(circle_at_20%_50%,rgba(236,72,153,0.3)_0%,transparent_50%)]' />
+        <div className='absolute inset-0 bg-[radial-gradient(circle_at_20%_50%,rgba(99,102,241,0.3)_0%,transparent_50%)]' />
         <div className='absolute inset-0 bg-[radial-gradient(circle_at_80%_20%,rgba(14,165,233,0.3)_0%,transparent_50%)]' />
-        <div className='absolute inset-0 bg-[radial-gradient(circle_at_60%_80%,rgba(168,85,247,0.25)_0%,transparent_40%)]' />
-        <div className='absolute inset-0 bg-[radial-gradient(circle_at_10%_10%,rgba(34,197,94,0.2)_0%,transparent_35%)]' />
-        <div className='absolute inset-0 bg-[radial-gradient(circle_at_90%_90%,rgba(251,146,60,0.22)_0%,transparent_45%)]' />
+        <div className='absolute inset-0 bg-[radial-gradient(circle_at_60%_80%,rgba(139,92,246,0.25)_0%,transparent_40%)]' />
       </div>
     </div>
   );

--- a/src/components/sections/ProjectsSection.jsx
+++ b/src/components/sections/ProjectsSection.jsx
@@ -20,46 +20,29 @@ import {
   Package,
 } from 'lucide-react';
 import { featuredProjects, allProjects } from '../../data/projects.jsx';
-import { use3DTilt, tiltPresets } from '../../hooks/use3DTilt.jsx';
 import { useRipple } from '../../hooks';
 
-// Project Card with 3D Tilt Effect
+// Project Card
 const ProjectCard = ({ project, index, inView }) => {
-  const { elementRef, tiltStyle, glareElementStyle } = use3DTilt(tiltPresets.card);
-
   return (
     <motion.div
-      ref={elementRef}
       key={project.id}
-      initial={{ opacity: 0, y: 60 }}
+      initial={{ opacity: 0, y: 40 }}
       animate={inView ? { opacity: 1, y: 0 } : {}}
-      transition={{ duration: 0.8, delay: index * 0.2 }}
-      style={tiltStyle}
+      transition={{ duration: 0.6, delay: index * 0.15 }}
       className='group relative h-full'
     >
-      {/* Optimized Glassmorphism Card with Enhanced Gradient Animation */}
-      <div className='relative h-full bg-white/90 backdrop-blur-sm rounded-3xl p-8 lg:p-10 border border-white/30 shadow-xl hover:shadow-2xl transition-all duration-500 overflow-hidden'>
-        {/* Glare effect */}
-        <div style={glareElementStyle} />
-
-        {/* Enhanced Multi-layer Background Gradients */}
-        <div className='absolute inset-0 bg-linear-to-br from-secondary-500/5 via-accent-500/5 to-emerald-500/5 opacity-0 group-hover:opacity-100 transition-opacity duration-500'></div>
-        <div className='absolute inset-0 bg-linear-to-tl from-blue-500/3 via-purple-500/3 to-teal-500/3 opacity-0 group-hover:opacity-80 transition-opacity duration-700'></div>
-        <div className='absolute inset-0 bg-linear-to-r from-transparent via-white/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300'></div>
-
-        {/* Enhanced Floating Orbs with Gradient Animation */}
-        <div className='absolute -top-20 -right-20 w-40 h-40 bg-linear-to-br from-secondary-400/20 via-accent-400/20 to-purple-400/20 rounded-full blur-3xl opacity-0 group-hover:opacity-100 transition-all duration-700'></div>
-        <div className='absolute -bottom-20 -left-20 w-32 h-32 bg-linear-to-br from-emerald-400/20 via-teal-400/20 to-blue-400/20 rounded-full blur-3xl opacity-0 group-hover:opacity-100 transition-all duration-900'></div>
-        <div className='absolute top-1/2 right-1/4 w-20 h-20 bg-linear-to-br from-pink-400/15 via-violet-400/15 to-cyan-400/15 rounded-full blur-2xl opacity-0 group-hover:opacity-100 transition-all duration-600'></div>
+      {/* Card */}
+      <div className='relative h-full bg-white rounded-3xl p-8 lg:p-10 border border-gray-100 shadow-sm hover:shadow-xl transition-shadow duration-300 overflow-hidden'>
+        {/* One subtle indigo→sky wash on hover — the single decorative layer. */}
+        <div className='absolute inset-0 bg-linear-to-br from-secondary-500/[0.03] to-accent-500/[0.03] opacity-0 group-hover:opacity-100 transition-opacity duration-300'></div>
 
         <div className='relative z-10 flex flex-col'>
           {/* Project Icon and Title */}
           <div className='text-center'>
             <div className='flex items-center justify-center mb-6'>
-              <div className='relative p-4 bg-linear-to-br from-secondary-500 via-accent-500 to-purple-600 rounded-2xl text-white shadow-lg group-hover:shadow-xl transition-all duration-300'>
+              <div className='p-4 bg-linear-to-br from-secondary-500 to-accent-500 rounded-2xl text-white shadow-md group-hover:shadow-lg transition-shadow duration-300'>
                 {project.icon}
-                <div className='absolute inset-0 bg-linear-to-br from-white/10 via-white/5 to-transparent rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-300'></div>
-                <div className='absolute inset-0 bg-linear-to-tl from-transparent via-secondary-300/20 to-accent-300/20 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-500'></div>
               </div>
             </div>
 


### PR DESCRIPTION
**Stacked on #90** — base is `feat/unify-palette`. Final of the 4-part visual pass.

## What

**Project cards** — were carrying 3 full-card hover-gradient layers + 3 floating blur orbs (pink/violet/cyan) + a glare overlay + a 3D mouse-tilt. Replaced with a clean card: one subtle indigo→sky hover wash, simpler icon, no tilt, no orbs.

**Hero mesh** (`AnimatedMeshGradient`) — retuned from a 6-family rainbow (pink/blue/purple/green/sky/orange) to a cohesive **indigo/sky/violet** cool palette. Kept the animated orbs (hero still feels alive), dropped the clash. Removes the last hardcoded pink on the site.

## Verify

lint · test (4/4) · format:check · build green. Net −19 lines. Previewed full stack — no pink anywhere, cards read clean on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)