### PR TITLE
feat(ui): visual polish — display font, calm headings, indigo palette, less decoration

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap"
       rel="stylesheet"
     />
 

--- a/src/components/background/AnimatedMeshGradient.jsx
+++ b/src/components/background/AnimatedMeshGradient.jsx
@@ -12,14 +12,14 @@ const AnimatedMeshGradient = () => {
   return (
     <div className='absolute inset-0 overflow-hidden'>
       {/* Base gradient layers */}
-      <div className='absolute inset-0 bg-linear-to-br from-slate-900 via-purple-900 to-slate-900' />
-      <div className='absolute inset-0 bg-linear-to-tr from-blue-900/40 via-transparent to-pink-900/40' />
+      <div className='absolute inset-0 bg-linear-to-br from-slate-900 via-indigo-950 to-slate-900' />
+      <div className='absolute inset-0 bg-linear-to-tr from-indigo-900/40 via-transparent to-sky-900/40' />
 
       {/* Animated gradient orbs */}
       <motion.div
         className='absolute top-0 left-0 w-[500px] h-[500px] rounded-full'
         style={{
-          background: 'radial-gradient(circle, rgba(236,72,153,0.4) 0%, transparent 70%)',
+          background: 'radial-gradient(circle, rgba(99,102,241,0.4) 0%, transparent 70%)',
           filter: 'blur(80px)',
         }}
         animate={{
@@ -73,7 +73,7 @@ const AnimatedMeshGradient = () => {
       <motion.div
         className='absolute top-1/2 left-1/2 w-[550px] h-[550px] rounded-full'
         style={{
-          background: 'radial-gradient(circle, rgba(34,197,94,0.25) 0%, transparent 70%)',
+          background: 'radial-gradient(circle, rgba(14,165,233,0.25) 0%, transparent 70%)',
           filter: 'blur(85px)',
         }}
         animate={{
@@ -88,13 +88,11 @@ const AnimatedMeshGradient = () => {
         }}
       />
 
-      {/* Mesh pattern overlay */}
+      {/* Mesh pattern overlay — indigo / sky / violet, cohesive cool tones. */}
       <div className='absolute inset-0 opacity-30'>
-        <div className='absolute inset-0 bg-[radial-gradient(circle_at_20%_50%,rgba(236,72,153,0.3)_0%,transparent_50%)]' />
+        <div className='absolute inset-0 bg-[radial-gradient(circle_at_20%_50%,rgba(99,102,241,0.3)_0%,transparent_50%)]' />
         <div className='absolute inset-0 bg-[radial-gradient(circle_at_80%_20%,rgba(14,165,233,0.3)_0%,transparent_50%)]' />
-        <div className='absolute inset-0 bg-[radial-gradient(circle_at_60%_80%,rgba(168,85,247,0.25)_0%,transparent_40%)]' />
-        <div className='absolute inset-0 bg-[radial-gradient(circle_at_10%_10%,rgba(34,197,94,0.2)_0%,transparent_35%)]' />
-        <div className='absolute inset-0 bg-[radial-gradient(circle_at_90%_90%,rgba(251,146,60,0.22)_0%,transparent_45%)]' />
+        <div className='absolute inset-0 bg-[radial-gradient(circle_at_60%_80%,rgba(139,92,246,0.25)_0%,transparent_40%)]' />
       </div>
     </div>
   );

--- a/src/components/sections/AboutSection.jsx
+++ b/src/components/sections/AboutSection.jsx
@@ -62,10 +62,8 @@ const AboutSection = React.memo(() => {
             </span>
           </motion.div>
 
-          <h2 className='text-4xl lg:text-5xl font-black mb-6 text-gray-900'>
-            <span className='bg-linear-to-r from-gray-900 via-blue-800 to-gray-900 bg-clip-text text-transparent'>
-              Where software meets silicon
-            </span>
+          <h2 className='text-4xl lg:text-5xl font-bold mb-6 text-gray-900'>
+            Where software meets <span className='text-accent-600'>silicon</span>
           </h2>
           <p className='text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed'>
             Chasing microseconds on AI hardware — and running my own cloud for the fun of it
@@ -152,11 +150,7 @@ const AboutSection = React.memo(() => {
 
                 {/* Content */}
                 <div className='relative z-10'>
-                  <div
-                    className={`text-3xl font-black mb-1 bg-linear-to-r ${stat.color} bg-clip-text text-transparent`}
-                  >
-                    {stat.number}
-                  </div>
+                  <div className='text-3xl font-black mb-1 text-accent-600'>{stat.number}</div>
                   <div className='text-gray-600 font-semibold text-base'>{stat.label}</div>
                 </div>
 

--- a/src/components/sections/ContactSection.jsx
+++ b/src/components/sections/ContactSection.jsx
@@ -139,10 +139,8 @@ const ContactSection = () => {
             </span>
           </motion.div>
 
-          <h2 className='text-4xl lg:text-5xl font-black mb-6 text-gray-900'>
-            <span className='bg-linear-to-r from-green-600 via-blue-600 to-green-600 bg-clip-text text-transparent'>
-              Let's Work Together
-            </span>
+          <h2 className='text-4xl lg:text-5xl font-bold mb-6 text-gray-900'>
+            Let&apos;s <span className='text-accent-600'>Work</span> Together
           </h2>
           <p className='text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed'>
             Ready to bring your ideas to life? Let's discuss your next project and create something

--- a/src/components/sections/ExperienceSection.jsx
+++ b/src/components/sections/ExperienceSection.jsx
@@ -45,11 +45,7 @@ const ExperienceSection = () => {
             </span>
           </motion.div>
 
-          <h2 className='text-4xl lg:text-5xl font-black mb-6 text-gray-900'>
-            <span className='bg-linear-to-r from-blue-600 via-indigo-600 to-blue-600 bg-clip-text text-transparent'>
-              Experience
-            </span>
-          </h2>
+          <h2 className='text-4xl lg:text-5xl font-bold mb-6 text-gray-900'>Experience</h2>
           <p className='text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed'>
             Building innovative solutions and driving technological excellence across diverse
             industries

--- a/src/components/sections/HeroSection.jsx
+++ b/src/components/sections/HeroSection.jsx
@@ -62,7 +62,7 @@ const HeroSection = React.memo(function HeroSection() {
             </motion.div>
 
             <motion.h1
-              className='text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-black mb-4 md:mb-6 leading-tight'
+              className='text-4xl sm:text-5xl md:text-6xl lg:text-7xl font-bold mb-4 md:mb-6 leading-tight'
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ delay: 0.2 }}

--- a/src/components/sections/ProjectsSection.jsx
+++ b/src/components/sections/ProjectsSection.jsx
@@ -20,46 +20,29 @@ import {
   Package,
 } from 'lucide-react';
 import { featuredProjects, allProjects } from '../../data/projects.jsx';
-import { use3DTilt, tiltPresets } from '../../hooks/use3DTilt.jsx';
 import { useRipple } from '../../hooks';
 
-// Project Card with 3D Tilt Effect
+// Project Card
 const ProjectCard = ({ project, index, inView }) => {
-  const { elementRef, tiltStyle, glareElementStyle } = use3DTilt(tiltPresets.card);
-
   return (
     <motion.div
-      ref={elementRef}
       key={project.id}
-      initial={{ opacity: 0, y: 60 }}
+      initial={{ opacity: 0, y: 40 }}
       animate={inView ? { opacity: 1, y: 0 } : {}}
-      transition={{ duration: 0.8, delay: index * 0.2 }}
-      style={tiltStyle}
+      transition={{ duration: 0.6, delay: index * 0.15 }}
       className='group relative h-full'
     >
-      {/* Optimized Glassmorphism Card with Enhanced Gradient Animation */}
-      <div className='relative h-full bg-white/90 backdrop-blur-sm rounded-3xl p-8 lg:p-10 border border-white/30 shadow-xl hover:shadow-2xl transition-all duration-500 overflow-hidden'>
-        {/* Glare effect */}
-        <div style={glareElementStyle} />
-
-        {/* Enhanced Multi-layer Background Gradients */}
-        <div className='absolute inset-0 bg-linear-to-br from-secondary-500/5 via-accent-500/5 to-emerald-500/5 opacity-0 group-hover:opacity-100 transition-opacity duration-500'></div>
-        <div className='absolute inset-0 bg-linear-to-tl from-blue-500/3 via-purple-500/3 to-teal-500/3 opacity-0 group-hover:opacity-80 transition-opacity duration-700'></div>
-        <div className='absolute inset-0 bg-linear-to-r from-transparent via-white/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300'></div>
-
-        {/* Enhanced Floating Orbs with Gradient Animation */}
-        <div className='absolute -top-20 -right-20 w-40 h-40 bg-linear-to-br from-secondary-400/20 via-accent-400/20 to-purple-400/20 rounded-full blur-3xl opacity-0 group-hover:opacity-100 transition-all duration-700'></div>
-        <div className='absolute -bottom-20 -left-20 w-32 h-32 bg-linear-to-br from-emerald-400/20 via-teal-400/20 to-blue-400/20 rounded-full blur-3xl opacity-0 group-hover:opacity-100 transition-all duration-900'></div>
-        <div className='absolute top-1/2 right-1/4 w-20 h-20 bg-linear-to-br from-pink-400/15 via-violet-400/15 to-cyan-400/15 rounded-full blur-2xl opacity-0 group-hover:opacity-100 transition-all duration-600'></div>
+      {/* Card */}
+      <div className='relative h-full bg-white rounded-3xl p-8 lg:p-10 border border-gray-100 shadow-sm hover:shadow-xl transition-shadow duration-300 overflow-hidden'>
+        {/* One subtle indigo→sky wash on hover — the single decorative layer. */}
+        <div className='absolute inset-0 bg-linear-to-br from-secondary-500/[0.03] to-accent-500/[0.03] opacity-0 group-hover:opacity-100 transition-opacity duration-300'></div>
 
         <div className='relative z-10 flex flex-col'>
           {/* Project Icon and Title */}
           <div className='text-center'>
             <div className='flex items-center justify-center mb-6'>
-              <div className='relative p-4 bg-linear-to-br from-secondary-500 via-accent-500 to-purple-600 rounded-2xl text-white shadow-lg group-hover:shadow-xl transition-all duration-300'>
+              <div className='p-4 bg-linear-to-br from-secondary-500 to-accent-500 rounded-2xl text-white shadow-md group-hover:shadow-lg transition-shadow duration-300'>
                 {project.icon}
-                <div className='absolute inset-0 bg-linear-to-br from-white/10 via-white/5 to-transparent rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-300'></div>
-                <div className='absolute inset-0 bg-linear-to-tl from-transparent via-secondary-300/20 to-accent-300/20 rounded-2xl opacity-0 group-hover:opacity-100 transition-opacity duration-500'></div>
               </div>
             </div>
 
@@ -232,10 +215,8 @@ const ProjectsSection = () => {
             </span>
           </motion.div>
 
-          <h2 className='text-5xl lg:text-6xl font-black mb-8 text-gray-900 leading-tight'>
-            <span className='bg-linear-to-r from-emerald-600 via-teal-600 to-blue-600 bg-clip-text text-transparent'>
-              Featured Projects
-            </span>
+          <h2 className='text-5xl lg:text-6xl font-bold mb-8 text-gray-900 leading-tight'>
+            Featured <span className='text-accent-600'>Projects</span>
           </h2>
           <p className='text-xl text-gray-600 max-w-4xl mx-auto leading-relaxed'>
             Innovative solutions powered by machine learning and cutting-edge technology

--- a/src/components/sections/SkillsSection.jsx
+++ b/src/components/sections/SkillsSection.jsx
@@ -70,10 +70,8 @@ const SkillsSection = () => {
             </span>
           </motion.div>
 
-          <h2 className='text-4xl lg:text-5xl font-black mb-6 text-gray-900'>
-            <span className='bg-linear-to-r from-purple-600 via-pink-600 to-purple-600 bg-clip-text text-transparent'>
-              What I Do Best
-            </span>
+          <h2 className='text-4xl lg:text-5xl font-bold mb-6 text-gray-900'>
+            What I Do <span className='text-accent-600'>Best</span>
           </h2>
           <p className='text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed'>
             Passionate about technologies that drive innovation and create meaningful impact

--- a/src/components/sections/TechnologiesSection.jsx
+++ b/src/components/sections/TechnologiesSection.jsx
@@ -86,10 +86,8 @@ const TechnologiesSection = () => {
             </span>
           </motion.div>
 
-          <h2 className='text-4xl md:text-5xl font-black mb-6 text-gray-900'>
-            <span className='bg-linear-to-r from-indigo-600 via-purple-600 to-indigo-600 bg-clip-text text-transparent'>
-              Technologies & Platforms
-            </span>
+          <h2 className='text-4xl md:text-5xl font-bold mb-6 text-gray-900'>
+            Technologies &amp; <span className='text-accent-600'>Platforms</span>
           </h2>
           <p className='text-xl text-gray-600 max-w-3xl mx-auto leading-relaxed'>
             Comprehensive experience across cloud platforms, operating systems, networking, and

--- a/src/index.css
+++ b/src/index.css
@@ -12,16 +12,20 @@
   --color-primary-800: #1e293b;
   --color-primary-900: #0f172a;
 
-  --color-secondary-50: #fdf2f8;
-  --color-secondary-100: #fce7f3;
-  --color-secondary-200: #fbcfe8;
-  --color-secondary-300: #f9a8d4;
-  --color-secondary-400: #f472b6;
-  --color-secondary-500: #ec4899;
-  --color-secondary-600: #db2777;
-  --color-secondary-700: #be185d;
-  --color-secondary-800: #9d174d;
-  --color-secondary-900: #831843;
+  /* Secondary = indigo. Retuned from the original pink (#ec4899) so the whole
+     site reads as a cohesive indigo→sky cool palette instead of pink-heavy.
+     Pairs with the sky-blue accent below; updating the token reskins all
+     usages (buttons, badges, gradients) without touching className strings. */
+  --color-secondary-50: #eef2ff;
+  --color-secondary-100: #e0e7ff;
+  --color-secondary-200: #c7d2fe;
+  --color-secondary-300: #a5b4fc;
+  --color-secondary-400: #818cf8;
+  --color-secondary-500: #6366f1;
+  --color-secondary-600: #4f46e5;
+  --color-secondary-700: #4338ca;
+  --color-secondary-800: #3730a3;
+  --color-secondary-900: #312e81;
 
   --color-accent-50: #f0f9ff;
   --color-accent-100: #e0f2fe;
@@ -57,7 +61,7 @@
   --color-warning-900: #78350f;
 
   --font-sans: Inter, system-ui, sans-serif;
-  --font-display: Cal Sans, Inter, system-ui, sans-serif;
+  --font-display: 'Space Grotesk', Inter, system-ui, sans-serif;
 
   --animate-float: float 3s ease-in-out infinite;
   --animate-fadeInUp: fadeInUp 0.8s ease-out;
@@ -72,9 +76,6 @@
     from 180deg at 50% 50%,
     var(--tw-gradient-stops)
   );
-  --background-image-gradient-modern: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-  --background-image-gradient-dark: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
-  --background-image-gradient-accent: linear-gradient(135deg, #ec4899 0%, #8b5cf6 100%);
 
   --backdrop-blur-xs: 2px;
 
@@ -251,6 +252,16 @@
     padding: 0;
     position: relative;
     scroll-behavior: smooth;
+  }
+
+  /* Headings use the display font (Space Grotesk) with slightly tighter
+     tracking, giving titles typographic character distinct from Inter body.
+     Note: Space Grotesk's heaviest weight is 700 — heading elements use
+     font-bold (700), not font-black (900), to avoid synthetic fake-bold. */
+  h1,
+  h2,
+  h3 {
+    @apply font-display tracking-tight;
   }
 
   #root {


### PR DESCRIPTION
A single coherent professional-feel pass over the whole site. **Consolidates and replaces the stacked PRs #88/#89/#90/#91** (collapsed to one because they're one visual change and the stack hit cross-file conflicts).

## Changes

**Typography** — load **Space Grotesk** and apply it to headings. `--font-display` previously pointed at Cal Sans, which was never loaded (headings silently fell back to Inter). Headings use `font-bold` (700) — Space Grotesk's heaviest weight; `font-black` (900) would make the browser synthesize a muddy fake-bold *(caught by Copilot on #88)*. Body stays Inter.

**Headings** — replace six rainbow `bg-clip-text` gradients with **near-black + one accent word** each (silicon / Best / Platforms / Projects / Work). The hero `<h1>` "Aswin" keeps its gradient — on the dark mesh it's the one brand moment where gradient text earns its place, and now the only gradient text on the page.

**Palette** — retune the `secondary` token from **pink (#ec4899) → indigo**, reskinning all ~76 usages (buttons, badges, gradients) to a cohesive **indigo→sky** identity with zero className churn. Delete three dead `gradient-image` tokens.

**Decoration** — strip ProjectsSection card noise (3D mouse-tilt, 3 floating orbs, glare, 3 hover-gradient layers) down to a clean card with one subtle hover wash. Retune the hero mesh from a 6-family rainbow to indigo/sky/violet.

## Verify

lint · test (4/4) · format:check · build green. Net **−26 lines**. Previewed locally end-to-end across all sections at desktop + mobile widths; confirmed via the local preview at each step (font, headings, palette, decoration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)