### PR TITLE
fix(ui): address Copilot follow-ups — font weight + leftover pink

### DIFF
--- a/src/components/ScrollProgress.jsx
+++ b/src/components/ScrollProgress.jsx
@@ -22,13 +22,13 @@ const ScrollProgress = () => {
     <>
       {/* Top scroll progress bar */}
       <motion.div
-        className='pointer-events-none fixed top-0 left-0 right-0 h-1 origin-left z-9999 bg-linear-to-r from-pink-500 via-purple-500 to-cyan-500'
+        className='pointer-events-none fixed top-0 left-0 right-0 h-1 origin-left z-9999 bg-linear-to-r from-secondary-500 via-accent-500 to-secondary-600'
         style={{ scaleX, opacity }}
       />
 
       {/* Glow effect */}
       <motion.div
-        className='pointer-events-none fixed top-0 left-0 right-0 h-1 origin-left z-9998 bg-linear-to-r from-pink-500/50 via-purple-500/50 to-cyan-500/50 blur-xs'
+        className='pointer-events-none fixed top-0 left-0 right-0 h-1 origin-left z-9998 bg-linear-to-r from-secondary-500/50 via-accent-500/50 to-secondary-600/50 blur-xs'
         style={{ scaleX, opacity }}
       />
     </>

--- a/src/components/sections/AboutSection.jsx
+++ b/src/components/sections/AboutSection.jsx
@@ -21,19 +21,19 @@ const AboutSection = React.memo(() => {
       number: experience,
       label: 'Years Experience',
       icon: <Briefcase size={24} />,
-      color: 'from-blue-500 to-cyan-500',
+      color: 'from-secondary-500 to-accent-500',
     },
     {
       number: 'Software',
       label: 'Development',
       icon: <Code size={24} />,
-      color: 'from-purple-500 to-pink-500',
+      color: 'from-accent-500 to-secondary-600',
     },
     {
       number: 'Cloud',
       label: 'Technologies',
       icon: <Cloud size={24} />,
-      color: 'from-emerald-500 to-teal-500',
+      color: 'from-secondary-600 to-accent-600',
     },
   ];
 
@@ -54,9 +54,9 @@ const AboutSection = React.memo(() => {
             initial={{ opacity: 0, scale: 0.8 }}
             animate={inView ? { opacity: 1, scale: 1 } : {}}
             transition={{ duration: 0.6, delay: 0.2 }}
-            className='inline-flex items-center space-x-2 bg-linear-to-r from-blue-500/10 to-purple-500/10 rounded-full px-6 py-3 mb-6 backdrop-blur-sm border border-blue-200/30'
+            className='inline-flex items-center space-x-2 bg-linear-to-r from-secondary-500/10 to-accent-500/10 rounded-full px-6 py-3 mb-6 backdrop-blur-sm border border-secondary-200/30'
           >
-            <Circle size={8} className='text-blue-500 fill-current' />
+            <Circle size={8} className='text-secondary-500 fill-current' />
             <span className='text-sm font-semibold text-gray-600 uppercase tracking-wide'>
               About Me
             </span>
@@ -79,34 +79,35 @@ const AboutSection = React.memo(() => {
           >
             <div className='space-y-6 text-lg text-gray-700 leading-relaxed'>
               <div className='relative'>
-                <div className='absolute -left-4 top-0 w-1 h-full bg-linear-to-b from-blue-500 to-purple-500 rounded-full'></div>
+                <div className='absolute -left-4 top-0 w-1 h-full bg-linear-to-b from-secondary-500 to-accent-500 rounded-full'></div>
                 <p className='pl-8'>
-                  I'm a <span className='font-semibold text-blue-600'>performance engineer</span>{' '}
+                  I'm a{' '}
+                  <span className='font-semibold text-secondary-600'>performance engineer</span>{' '}
                   based in Pondicherry, working at MulticoreWare on the software that runs on{' '}
-                  <span className='font-semibold text-blue-600'>AI accelerator hardware</span>. Most
-                  days that means profiling tensor operations, hunting bottlenecks, and turning
+                  <span className='font-semibold text-secondary-600'>AI accelerator hardware</span>.
+                  Most days that means profiling tensor operations, hunting bottlenecks, and turning
                   benchmark numbers into something faster.
                 </p>
               </div>
 
               <div className='relative'>
-                <div className='absolute -left-4 top-0 w-1 h-full bg-linear-to-b from-purple-500 to-pink-500 rounded-full'></div>
+                <div className='absolute -left-4 top-0 w-1 h-full bg-linear-to-b from-accent-500 to-secondary-500 rounded-full'></div>
                 <p className='pl-8'>
                   The work I enjoy lives close to the metal — where a data layout, a kernel choice,
                   or a scheduling decision is the difference between fast and{' '}
-                  <span className='font-semibold text-purple-600'>genuinely fast</span>. I care
+                  <span className='font-semibold text-secondary-600'>genuinely fast</span>. I care
                   about measuring before optimizing, and about making the optimization stick.
                 </p>
               </div>
 
               <div className='relative'>
-                <div className='absolute -left-4 top-0 w-1 h-full bg-linear-to-b from-pink-500 to-emerald-500 rounded-full'></div>
+                <div className='absolute -left-4 top-0 w-1 h-full bg-linear-to-b from-secondary-500 to-accent-500 rounded-full'></div>
                 <p className='pl-8'>
                   Off the clock, I run{' '}
-                  <span className='font-semibold text-emerald-600'>my own cloud</span> — self-hosted
-                  services behind Cloudflare tunnels, from this site to a support desk to an AI
-                  chat. It's where I get to be the ops team, the security team, and the person who
-                  gets paged, all at once.
+                  <span className='font-semibold text-secondary-600'>my own cloud</span> —
+                  self-hosted services behind Cloudflare tunnels, from this site to a support desk
+                  to an AI chat. It's where I get to be the ops team, the security team, and the
+                  person who gets paged, all at once.
                 </p>
               </div>
             </div>
@@ -150,7 +151,7 @@ const AboutSection = React.memo(() => {
 
                 {/* Content */}
                 <div className='relative z-10'>
-                  <div className='text-3xl font-black mb-1 text-accent-600'>{stat.number}</div>
+                  <div className='text-3xl font-extrabold mb-1 text-accent-600'>{stat.number}</div>
                   <div className='text-gray-600 font-semibold text-base'>{stat.label}</div>
                 </div>
 

--- a/src/components/sections/SkillsSection.jsx
+++ b/src/components/sections/SkillsSection.jsx
@@ -26,8 +26,8 @@ const SkillsSection = () => {
       icon: <Zap size={48} />,
       title: 'Performance Optimization',
       description: 'Profiling, benchmarking, and performance analysis for applications',
-      color: 'from-purple-500 to-pink-600',
-      bgColor: 'from-purple-50 to-pink-50',
+      color: 'from-secondary-500 to-secondary-700',
+      bgColor: 'from-secondary-50 to-indigo-100',
     },
     {
       icon: <Cpu size={48} />,
@@ -48,7 +48,7 @@ const SkillsSection = () => {
   return (
     <section id='skills' className='section-padding bg-white relative overflow-hidden'>
       {/* Subtle background tint — section color without the decoration noise. */}
-      <div className='absolute inset-0 bg-linear-to-br from-white via-purple-50/50 to-pink-50/50'></div>
+      <div className='absolute inset-0 bg-linear-to-br from-white via-secondary-50/50 to-accent-50/50'></div>
 
       <div className='container-custom relative z-10'>
         <motion.div
@@ -62,9 +62,9 @@ const SkillsSection = () => {
             initial={{ opacity: 0, scale: 0.8 }}
             animate={inView ? { opacity: 1, scale: 1 } : {}}
             transition={{ duration: 0.6, delay: 0.2 }}
-            className='inline-flex items-center space-x-2 bg-linear-to-r from-purple-500/10 to-pink-500/10 rounded-full px-6 py-3 mb-6 backdrop-blur-sm border border-purple-200/30'
+            className='inline-flex items-center space-x-2 bg-linear-to-r from-secondary-500/10 to-accent-500/10 rounded-full px-6 py-3 mb-6 backdrop-blur-sm border border-secondary-200/30'
           >
-            <Sparkles size={16} className='text-purple-500' />
+            <Sparkles size={16} className='text-secondary-500' />
             <span className='text-sm font-semibold text-gray-600 uppercase tracking-wide'>
               Skills & Expertise
             </span>


### PR DESCRIPTION
Two correct catches from Copilot's review of #92 that landed just after it merged.

## 1. `font-black` on a weight that isn't loaded
The About **stat number** used `font-black` (900), but Inter loads only **300–800** — so the browser synthesized a fake 900, the exact issue #92 fixed for headings. → `font-extrabold` (800), a real loaded weight.

## 2. Leftover hardcoded pink
The "removes the last pink" claim was overstated — `pink-*` literals remained in:
- **AboutSection** — stat colors, the 3 prose accent bars, inline text accents, eyebrow badge
- **SkillsSection** — the Performance-Optimization card, section background tint, eyebrow
- **ScrollProgress** — the visible top progress bar (`from-pink-500 via-purple-500 to-cyan-500`)

All retuned to the `secondary` (indigo) / `accent` (sky) tokens. **Zero `pink-*` literals remain in `src/`** (verified by grep). Per-card colour variety in Skills (blue/emerald/orange) is kept — only the pink card was changed.

## Verify

lint · test (4/4) · format:check · build green. `grep pink-` → none; `grep font-black` → none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)