### PR TITLE
feat(a11y): respect prefers-reduced-motion for Framer Motion

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -129,13 +129,13 @@ const App = () => {
   }, []);
 
   return (
-    <GlobalErrorHandler>
-      <ErrorBoundary level='app' fallbackComponent='Portfolio Application'>
-        {/* reducedMotion="user" makes every motion component respect the OS
-            "reduce motion" setting — animations are stripped to instant for
-            users who asked for it (the CSS media query only covers CSS
-            animations, not Framer Motion's JS-driven ones). */}
-        <MotionConfig reducedMotion='user'>
+    // reducedMotion="user" makes every motion/react component respect the OS
+    // "reduce motion" setting — animations render instantly for users who asked
+    // for it (the CSS media query only covers CSS animations, not the JS-driven
+    // ones). Outermost so even the ErrorBoundary fallback UI inherits it.
+    <MotionConfig reducedMotion='user'>
+      <GlobalErrorHandler>
+        <ErrorBoundary level='app' fallbackComponent='Portfolio Application'>
           <Router
             basename={getBasename()}
             future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
@@ -174,9 +174,9 @@ const App = () => {
               </Suspense>
             </Layout>
           </Router>
-        </MotionConfig>
-      </ErrorBoundary>
-    </GlobalErrorHandler>
+        </ErrorBoundary>
+      </GlobalErrorHandler>
+    </MotionConfig>
   );
 };
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@
 
 import React, { useEffect, lazy, Suspense } from 'react';
 import { BrowserRouter as Router, Routes, Route, useLocation } from 'react-router-dom';
+import { MotionConfig } from 'motion/react';
 import Navigation from './components/Navigation.jsx';
 import LoadingSpinner from './components/LoadingSpinner.jsx';
 import {
@@ -130,44 +131,50 @@ const App = () => {
   return (
     <GlobalErrorHandler>
       <ErrorBoundary level='app' fallbackComponent='Portfolio Application'>
-        <Router
-          basename={getBasename()}
-          future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-        >
-          <Layout>
-            <Suspense
-              fallback={<LoadingSpinner size='lg' text='Loading…' className='min-h-screen' />}
-            >
-              <Routes>
-                <Route path='/' element={<HomePage />} />
-                <Route
-                  path='/privacy'
-                  element={
-                    <ErrorBoundary level='page' fallbackComponent='Privacy Policy'>
-                      <PrivacyPolicy />
-                    </ErrorBoundary>
-                  }
-                />
-                <Route
-                  path='/terms'
-                  element={
-                    <ErrorBoundary level='page' fallbackComponent='Terms & Conditions'>
-                      <TermsConditions />
-                    </ErrorBoundary>
-                  }
-                />
-                <Route
-                  path='*'
-                  element={
-                    <ErrorBoundary level='page' fallbackComponent='404 Page'>
-                      <NotFound />
-                    </ErrorBoundary>
-                  }
-                />
-              </Routes>
-            </Suspense>
-          </Layout>
-        </Router>
+        {/* reducedMotion="user" makes every motion component respect the OS
+            "reduce motion" setting — animations are stripped to instant for
+            users who asked for it (the CSS media query only covers CSS
+            animations, not Framer Motion's JS-driven ones). */}
+        <MotionConfig reducedMotion='user'>
+          <Router
+            basename={getBasename()}
+            future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+          >
+            <Layout>
+              <Suspense
+                fallback={<LoadingSpinner size='lg' text='Loading…' className='min-h-screen' />}
+              >
+                <Routes>
+                  <Route path='/' element={<HomePage />} />
+                  <Route
+                    path='/privacy'
+                    element={
+                      <ErrorBoundary level='page' fallbackComponent='Privacy Policy'>
+                        <PrivacyPolicy />
+                      </ErrorBoundary>
+                    }
+                  />
+                  <Route
+                    path='/terms'
+                    element={
+                      <ErrorBoundary level='page' fallbackComponent='Terms & Conditions'>
+                        <TermsConditions />
+                      </ErrorBoundary>
+                    }
+                  />
+                  <Route
+                    path='*'
+                    element={
+                      <ErrorBoundary level='page' fallbackComponent='404 Page'>
+                        <NotFound />
+                      </ErrorBoundary>
+                    }
+                  />
+                </Routes>
+              </Suspense>
+            </Layout>
+          </Router>
+        </MotionConfig>
       </ErrorBoundary>
     </GlobalErrorHandler>
   );


### PR DESCRIPTION
## What

The CSS `@media (prefers-reduced-motion)` rule only neutralizes **CSS** animations. Every `motion.*` component (hero entrance, section fade-ups, card reveals, nav) is **JS-driven** by Framer Motion and kept fully animating for users who set "reduce motion" — a real accessibility gap.

Wrap the app in `<MotionConfig reducedMotion="user">` — one provider makes all 18 motion-using components honor the OS setting and render instantly for those users. No per-component changes.

## Verify

lint · test (4/4) · build · format green. Confirmed `reducedMotion` in the built bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)