### PR TITLE
chore: remove portfolio smoke-test line

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,5 +118,3 @@ Visit the live portfolio: **[www.aswincloud.com](https://www.aswincloud.com)**
 ---
 
 Built with ❤️ by [Aswin](https://github.com/Aswincloud) | Software Engineer at MulticoreWare
-
-<!-- merge-queue smoke test (retry) 2026-07-03 — throwaway -->


### PR DESCRIPTION
Cleanup: reverts the throwaway README line from the merge-queue smoke test (#115).