### PR TITLE
test: add end-to-end (Playwright) tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,19 @@ jobs:
       - run: npm ci
       - name: npm audit
         run: npm run security:check
+
+  e2e:
+    name: 🎭 E2E
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.0.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+      - name: Run E2E tests
+        run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ temp/
 
 # Cloudflare Workers
 public/_redirects 
+# Playwright
+test-results/
+playwright-report/

--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -1,22 +1,30 @@
-import { test, expect } from '@playwright/test';
+/**
+ * @file e2e/smoke.spec.js
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @author Aswin
+ * @description End-to-end (Playwright) test harness.
+ */
+import { test, expect } from "@playwright/test";
 
-test('home page loads and renders the app', async ({ page }) => {
-  const resp = await page.goto('/');
+test("home page loads and renders the app", async ({ page }) => {
+  const resp = await page.goto("/");
   expect(resp?.ok()).toBeTruthy();
   await expect(page).toHaveTitle(/Aswin/i);
   // App actually mounted something visible (not a blank white page).
-  await expect(page.locator('body')).not.toBeEmpty();
-  await expect(page.locator('#root, #app, main, body > *').first()).toBeVisible();
+  await expect(page.locator("body")).not.toBeEmpty();
+  await expect(
+    page.locator("#root, #app, main, body > *").first(),
+  ).toBeVisible();
 });
 
-test('no uncaught page errors on load', async ({ page }) => {
+test("no uncaught page errors on load", async ({ page }) => {
   // Track only real JS exceptions (pageerror). We avoid asserting on
   // console.error and avoid networkidle (analytics can keep the socket open),
   // which would make the test flaky.
   const pageErrors = [];
-  page.on('pageerror', e => pageErrors.push(String(e)));
-  await page.goto('/');
-  await page.waitForLoadState('domcontentloaded');
+  page.on("pageerror", (e) => pageErrors.push(String(e)));
+  await page.goto("/");
+  await page.waitForLoadState("domcontentloaded");
   await page.waitForTimeout(1500); // let deferred scripts run
-  expect(pageErrors, 'uncaught exceptions on load').toEqual([]);
+  expect(pageErrors, "uncaught exceptions on load").toEqual([]);
 });

--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+
+test('home page loads and renders the app', async ({ page }) => {
+  const resp = await page.goto('/');
+  expect(resp?.ok()).toBeTruthy();
+  await expect(page).toHaveTitle(/Aswin/i);
+  // App actually mounted something visible (not a blank white page).
+  await expect(page.locator('body')).not.toBeEmpty();
+  await expect(page.locator('#root, #app, main, body > *').first()).toBeVisible();
+});
+
+test('no uncaught page errors on load', async ({ page }) => {
+  // Track only real JS exceptions (pageerror). We avoid asserting on
+  // console.error and avoid networkidle (analytics can keep the socket open),
+  // which would make the test flaky.
+  const pageErrors = [];
+  page.on('pageerror', e => pageErrors.push(String(e)));
+  await page.goto('/');
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForTimeout(1500); // let deferred scripts run
+  expect(pageErrors, 'uncaught exceptions on load').toEqual([]);
+});

--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -2,27 +2,38 @@
  * @file e2e/smoke.spec.js
  * @copyright © 2025 Aswin. All rights reserved.
  * @author Aswin
- * @description End-to-end (Playwright) test harness.
+ * @description End-to-end (Playwright) smoke tests for the portfolio site.
  */
 import { test, expect } from '@playwright/test';
 
-test('home page loads and renders the app', async ({ page }) => {
+// Block third-party analytics/chat scripts so the tests measure the app itself,
+// not flaky external requests.
+test.beforeEach(async ({ page }) => {
+  await page.route(/googletagmanager\.com|google-analytics\.com|chatwoot|widget/i, r => r.abort());
+});
+
+test('app mounts and renders real content', async ({ page }) => {
   const resp = await page.goto('/');
   expect(resp?.ok()).toBeTruthy();
   await expect(page).toHaveTitle(/Aswin/i);
-  // App actually mounted something visible (not a blank white page).
-  await expect(page.locator('body')).not.toBeEmpty();
-  await expect(page.locator('#root, #app, main, body > *').first()).toBeVisible();
+
+  // Deterministic proof React actually rendered: #root gains child elements
+  // (a blank/failed mount leaves the static <div id="root"></div> empty).
+  const root = page.locator('#root');
+  await expect(root).toBeVisible();
+  await expect
+    .poll(async () => await root.locator(':scope > *').count(), { timeout: 15_000 })
+    .toBeGreaterThan(0);
+
+  // A real, user-visible heading is present (not just an empty shell).
+  await expect(page.getByRole('heading').first()).toBeVisible();
 });
 
-test('no uncaught page errors on load', async ({ page }) => {
-  // Track only real JS exceptions (pageerror). We avoid asserting on
-  // console.error and avoid networkidle (analytics can keep the socket open),
-  // which would make the test flaky.
+test('no uncaught exceptions from the app on load', async ({ page }) => {
   const pageErrors = [];
   page.on('pageerror', e => pageErrors.push(String(e)));
-  await page.goto('/');
-  await page.waitForLoadState('domcontentloaded');
-  await page.waitForTimeout(1500); // let deferred scripts run
+  // Wait for the app to actually render rather than a fixed timeout.
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page.locator('#root > *').first()).toBeVisible({ timeout: 15_000 });
   expect(pageErrors, 'uncaught exceptions on load').toEqual([]);
 });

--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -4,27 +4,25 @@
  * @author Aswin
  * @description End-to-end (Playwright) test harness.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test';
 
-test("home page loads and renders the app", async ({ page }) => {
-  const resp = await page.goto("/");
+test('home page loads and renders the app', async ({ page }) => {
+  const resp = await page.goto('/');
   expect(resp?.ok()).toBeTruthy();
   await expect(page).toHaveTitle(/Aswin/i);
   // App actually mounted something visible (not a blank white page).
-  await expect(page.locator("body")).not.toBeEmpty();
-  await expect(
-    page.locator("#root, #app, main, body > *").first(),
-  ).toBeVisible();
+  await expect(page.locator('body')).not.toBeEmpty();
+  await expect(page.locator('#root, #app, main, body > *').first()).toBeVisible();
 });
 
-test("no uncaught page errors on load", async ({ page }) => {
+test('no uncaught page errors on load', async ({ page }) => {
   // Track only real JS exceptions (pageerror). We avoid asserting on
   // console.error and avoid networkidle (analytics can keep the socket open),
   // which would make the test flaky.
   const pageErrors = [];
-  page.on("pageerror", (e) => pageErrors.push(String(e)));
-  await page.goto("/");
-  await page.waitForLoadState("domcontentloaded");
+  page.on('pageerror', e => pageErrors.push(String(e)));
+  await page.goto('/');
+  await page.waitForLoadState('domcontentloaded');
   await page.waitForTimeout(1500); // let deferred scripts run
-  expect(pageErrors, "uncaught exceptions on load").toEqual([]);
+  expect(pageErrors, 'uncaught exceptions on load').toEqual([]);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.3.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -696,6 +697,22 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -5191,6 +5208,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "pre-commit": "lint-staged",
     "validate": "npm run quality:check && npm run build",
     "clean": "rm -rf dist node_modules/.cache",
-    "analyze": "npm run build:analyze && npx vite-bundle-analyzer dist"
+    "analyze": "npm run build:analyze && npx vite-bundle-analyzer dist",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "lucide-react": "^0.577.0",
@@ -43,6 +45,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.61.0",
     "@tailwindcss/postcss": "^4.3.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// E2E: build the site, serve the production bundle, drive it in a real browser.
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  fullyParallel: true,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['list']] : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: 'npm run build && npm run preview -- --port 4173 --host 127.0.0.1',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -4,23 +4,23 @@
  * @author Aswin
  * @description End-to-end (Playwright) test harness.
  */
-import { defineConfig, devices } from "@playwright/test";
+import { defineConfig, devices } from '@playwright/test';
 
 // E2E: build the site, serve the production bundle, drive it in a real browser.
 export default defineConfig({
-  testDir: "./e2e",
+  testDir: './e2e',
   timeout: 30_000,
   fullyParallel: true,
   retries: process.env.CI ? 1 : 0,
-  reporter: process.env.CI ? [["github"], ["list"]] : "list",
+  reporter: process.env.CI ? [['github'], ['list']] : 'list',
   use: {
-    baseURL: "http://127.0.0.1:4173",
-    trace: "on-first-retry",
+    baseURL: 'http://127.0.0.1:4173',
+    trace: 'on-first-retry',
   },
-  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
   webServer: {
-    command: "npm run build && npm run preview -- --port 4173 --host 127.0.0.1",
-    url: "http://127.0.0.1:4173",
+    command: 'npm run build && npm run preview -- --port 4173 --host 127.0.0.1',
+    url: 'http://127.0.0.1:4173',
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
   },

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,20 +1,26 @@
-import { defineConfig, devices } from '@playwright/test';
+/**
+ * @file playwright.config.js
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @author Aswin
+ * @description End-to-end (Playwright) test harness.
+ */
+import { defineConfig, devices } from "@playwright/test";
 
 // E2E: build the site, serve the production bundle, drive it in a real browser.
 export default defineConfig({
-  testDir: './e2e',
+  testDir: "./e2e",
   timeout: 30_000,
   fullyParallel: true,
   retries: process.env.CI ? 1 : 0,
-  reporter: process.env.CI ? [['github'], ['list']] : 'list',
+  reporter: process.env.CI ? [["github"], ["list"]] : "list",
   use: {
-    baseURL: 'http://127.0.0.1:4173',
-    trace: 'on-first-retry',
+    baseURL: "http://127.0.0.1:4173",
+    trace: "on-first-retry",
   },
-  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
   webServer: {
-    command: 'npm run build && npm run preview -- --port 4173 --host 127.0.0.1',
-    url: 'http://127.0.0.1:4173',
+    command: "npm run build && npm run preview -- --port 4173 --host 127.0.0.1",
+    url: "http://127.0.0.1:4173",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
   },

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,25 +1,19 @@
-import { defineConfig } from "vitest/config";
-import react from "@vitejs/plugin-react";
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
   test: {
     // Playwright specs live in e2e/ and must not be collected by vitest.
-    exclude: ["e2e/**", "node_modules/**", "dist/**"],
-    environment: "jsdom",
-    setupFiles: ["./src/setupTests.js"],
+    exclude: ['e2e/**', 'node_modules/**', 'dist/**'],
+    environment: 'jsdom',
+    setupFiles: ['./src/setupTests.js'],
     globals: true,
     css: true,
     coverage: {
-      provider: "v8",
-      reporter: ["text", "json", "html"],
-      exclude: [
-        "node_modules/",
-        "dist/",
-        "**/*.config.js",
-        "**/*.config.ts",
-        "src/setupTests.js",
-      ],
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: ['node_modules/', 'dist/', '**/*.config.js', '**/*.config.ts', 'src/setupTests.js'],
     },
   },
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,17 +1,25 @@
-import { defineConfig } from 'vitest/config';
-import react from '@vitejs/plugin-react';
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
   test: {
-    environment: 'jsdom',
-    setupFiles: ['./src/setupTests.js'],
+    // Playwright specs live in e2e/ and must not be collected by vitest.
+    exclude: ["e2e/**", "node_modules/**", "dist/**"],
+    environment: "jsdom",
+    setupFiles: ["./src/setupTests.js"],
     globals: true,
     css: true,
     coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html'],
-      exclude: ['node_modules/', 'dist/', '**/*.config.js', '**/*.config.ts', 'src/setupTests.js'],
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      exclude: [
+        "node_modules/",
+        "dist/",
+        "**/*.config.js",
+        "**/*.config.ts",
+        "src/setupTests.js",
+      ],
     },
   },
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,11 +1,13 @@
 import { defineConfig } from 'vitest/config';
+import { configDefaults } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
   test: {
-    // Playwright specs live in e2e/ and must not be collected by vitest.
-    exclude: ['e2e/**', 'node_modules/**', 'dist/**'],
+    // Extend Vitest's defaults so we don't accidentally re-include dirs it
+    // intentionally skips; just add the Playwright e2e/ dir.
+    exclude: [...configDefaults.exclude, 'e2e/**'],
     environment: 'jsdom',
     setupFiles: ['./src/setupTests.js'],
     globals: true,


### PR DESCRIPTION
Adds real browser E2E via Playwright — builds the site, serves the production preview, and drives Chromium.

**Tests** (`e2e/smoke.spec.js`, verified passing locally):
- home page loads, correct `<title>`, app actually mounts (not a blank page)
- no uncaught JS exceptions on load

**CI:** new `🎭 E2E` job runs on push/PR/merge_group. After merge, add it to the ruleset's required checks to gate merges on it.

Run locally: `npm run test:e2e`.