### PR TITLE
ci: pass auto-approve secrets explicitly (drop `inherit`)

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -17,4 +17,10 @@ concurrency:
 jobs:
   approve:
     uses: Aswincloud/.github/.github/workflows/auto-approve.yml@main
-    secrets: inherit
+    # Pass ONLY the three secrets the reusable workflow declares — not
+    # `secrets: inherit`, which would forward every org secret (Cloudflare,
+    # Resend, PATs, ...) into a workflow that has no business seeing them.
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+      WRITE_ACCESS_PAT: ${{ secrets.WRITE_ACCESS_PAT }}


### PR DESCRIPTION
Hardening from Copilot's review: `secrets: inherit` forwards **all** org secrets (Cloudflare, Resend, PROJECTS_TOKEN, ORG_READ_TOKEN, ...) into the auto-approve run. This passes only the 3 the reusable workflow declares — `APP_ID`, `APP_PRIVATE_KEY`, `WRITE_ACCESS_PAT`.

I dismissed this in the prior PR with an incorrect claim that inherit 'only forwards needed secrets' — it doesn't. This is the fix.