### PR TITLE
feat: add résumé download link (hero + footer)

### DIFF
--- a/src/components/sections/Footer.jsx
+++ b/src/components/sections/Footer.jsx
@@ -39,6 +39,14 @@ const Footer = () => {
               >
                 Source Code
               </a>
+              <a
+                href='https://github.com/Aswincloud/resume/releases/latest/download/Aswin_Resume.pdf'
+                target='_blank'
+                rel='noopener noreferrer'
+                className='text-gray-500 hover:text-secondary-600 transition-colors duration-200'
+              >
+                Résumé
+              </a>
             </div>
           </div>
           <div className='flex space-x-4'>

--- a/src/components/sections/Footer.jsx
+++ b/src/components/sections/Footer.jsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { Mail, Linkedin, Github } from 'lucide-react';
+import { RESUME_URL } from '../../data/links.js';
 
 // Footer Component
 const Footer = () => {
@@ -40,7 +41,7 @@ const Footer = () => {
                 Source Code
               </a>
               <a
-                href='https://github.com/Aswincloud/resume/releases/latest/download/Aswin_Resume.pdf'
+                href={RESUME_URL}
                 target='_blank'
                 rel='noopener noreferrer'
                 className='text-gray-500 hover:text-secondary-600 transition-colors duration-200'

--- a/src/components/sections/HeroSection.jsx
+++ b/src/components/sections/HeroSection.jsx
@@ -11,10 +11,7 @@ import { Github, Linkedin, Mail, Briefcase, ArrowRight, FileText } from 'lucide-
 import { useExperienceCalculator, useThrottledScroll, useRipple } from '../../hooks';
 import { AnimatedMeshGradient } from '../background';
 import { useMicroInteractions } from '../../utils/microInteractions';
-
-// `/releases/latest/download/…` always resolves to the newest published
-// résumé, so this never goes stale when a new build is cut.
-const RESUME_URL = 'https://github.com/Aswincloud/resume/releases/latest/download/Aswin_Resume.pdf';
+import { RESUME_URL } from '../../data/links.js';
 
 const HeroSection = React.memo(function HeroSection() {
   const experience = useExperienceCalculator();

--- a/src/components/sections/HeroSection.jsx
+++ b/src/components/sections/HeroSection.jsx
@@ -7,10 +7,14 @@
 
 import React, { useState, useRef } from 'react';
 import { motion } from 'motion/react';
-import { Github, Linkedin, Mail, Briefcase, ArrowRight } from 'lucide-react';
+import { Github, Linkedin, Mail, Briefcase, ArrowRight, FileText } from 'lucide-react';
 import { useExperienceCalculator, useThrottledScroll, useRipple } from '../../hooks';
 import { AnimatedMeshGradient } from '../background';
 import { useMicroInteractions } from '../../utils/microInteractions';
+
+// `/releases/latest/download/…` always resolves to the newest published
+// résumé, so this never goes stale when a new build is cut.
+const RESUME_URL = 'https://github.com/Aswincloud/resume/releases/latest/download/Aswin_Resume.pdf';
 
 const HeroSection = React.memo(function HeroSection() {
   const experience = useExperienceCalculator();
@@ -129,6 +133,21 @@ const HeroSection = React.memo(function HeroSection() {
                     size={18}
                     className='transition-transform duration-200 group-hover:translate-x-1'
                   />
+                </span>
+              </motion.a>
+
+              <motion.a
+                href={RESUME_URL}
+                target='_blank'
+                rel='noopener noreferrer'
+                whileHover={variants.buttonHover}
+                whileTap={variants.buttonTap}
+                className='group relative px-8 py-4 bg-white/10 backdrop-blur-sm text-white font-semibold rounded-2xl border border-white/20 hover:bg-white/20 transition-colors duration-300 overflow-hidden'
+                aria-label='Download résumé (PDF, opens in a new tab)'
+              >
+                <span className='flex items-center justify-center space-x-2'>
+                  <FileText size={20} />
+                  <span>Résumé</span>
                 </span>
               </motion.a>
             </motion.div>

--- a/src/data/links.js
+++ b/src/data/links.js
@@ -1,0 +1,12 @@
+/**
+ * @file links.js
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Shared external links — single source of truth so URLs don't drift across components
+ */
+
+// Résumé PDF. The GitHub Releases `latest/download` path always resolves to the
+// newest published release, so this never needs a code change when a new
+// résumé build is cut.
+export const RESUME_URL =
+  'https://github.com/Aswincloud/resume/releases/latest/download/Aswin_Resume.pdf';

--- a/src/index.css
+++ b/src/index.css
@@ -450,20 +450,20 @@
     justify-content: center;
   }
 
-  /* Mobile button spacing - keep side by side */
+  /* Mobile button spacing — allow wrapping now that there are three CTAs, so a
+     375px screen reflows them instead of squeezing everything onto one row. */
   .hero-buttons {
     gap: 0.5rem !important;
     flex-direction: row !important;
+    flex-wrap: wrap !important;
     align-items: center !important;
     justify-content: center !important;
   }
 
   .hero-buttons a,
   .hero-buttons button {
-    flex: 1;
-    max-width: 140px;
     font-size: 0.875rem;
-    padding: 0.75rem 1rem;
+    padding: 0.75rem 1.25rem;
     justify-content: center;
   }
 


### PR DESCRIPTION
## What

Adds a downloadable résumé link in two places:

- **Hero** — a third CTA button (📄 Résumé) that opens the PDF in a new tab
- **Footer** — a *Résumé* text link next to Source Code

Both point at the GitHub Releases **`latest/download`** URL:
`https://github.com/Aswincloud/resume/releases/latest/download/Aswin_Resume.pdf`

That path auto-resolves to the newest published release, so the site never needs a code change when a new résumé is cut. Verified it resolves `302 → 302 → 200` with `content-disposition: attachment; filename=Aswin_Resume.pdf`.

## Also

The hero previously forced its two CTAs onto a single row on mobile with a hard `max-width: 140px`. With a third button that would overflow a 375px screen, so I let the row **wrap** instead.

## Verify

lint · test (4/4) · build · format all green. External links use `rel="noopener noreferrer"`; the hero button has a descriptive `aria-label`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)