### PR TITLE
fix(nav): opaque bar while mobile menu is open

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -56,7 +56,7 @@ const Navigation = React.memo(function Navigation() {
   return (
     <nav
       className={`fixed inset-x-0 top-0 z-50 transition-all duration-300 ${
-        scrolled || !isHomePage
+        scrolled || !isHomePage || isMenuOpen
           ? 'border-b border-hairline bg-ink/80 backdrop-blur-xl'
           : 'border-b border-transparent bg-transparent'
       }`}


### PR DESCRIPTION
## Problem
On mobile, opening the navigation menu **at the top of the home page** rendered the menu items as plain text overlaying the hero content — no backdrop behind them.

## Cause
The nav bar background is intentionally transparent at the top of the home page (`scrolled || !isHomePage`). The mobile sheet has no background of its own — it relies on the parent `<nav>` being opaque. So in the one state where the bar is transparent (home + not scrolled), the expanded sheet let hero content bleed through. It only reproduced at the top because any scroll already makes the bar opaque.

## Fix
Add `isMenuOpen` to the opaque-background condition, so the bar (and therefore the sheet) always has the solid `bg-ink/80 backdrop-blur-xl` backdrop while the menu is open. One-line change, reuses existing tokens.

## Verification
- Headless mobile (390×844): menu open at home top now shows a solid dark sheet; items legible, no bleed-through.
- Scrolled state and active-item highlight unchanged.
- Desktop unaffected (sheet is `md:hidden`).
- ESLint 0 warnings · Prettier clean · copyright valid · 4/4 unit tests · 0 vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)