### PR TITLE
chore(brand): wordmark aswin.dev → aswincloud

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -74,7 +74,7 @@ const Navigation = React.memo(function Navigation() {
               <Terminal size={18} />
             </span>
             <span className='font-mono text-sm font-semibold text-white'>
-              aswin<span className='text-brand-400'>.dev</span>
+              aswin<span className='text-brand-400'>cloud</span>
             </span>
           </Link>
 

--- a/src/components/sections/Footer.jsx
+++ b/src/components/sections/Footer.jsx
@@ -38,7 +38,7 @@ const Footer = () => {
                 <Terminal size={18} />
               </span>
               <span className='font-mono text-sm font-semibold text-white'>
-                aswin<span className='text-brand-400'>.dev</span>
+                aswin<span className='text-brand-400'>cloud</span>
               </span>
             </div>
             <p className='mt-4 text-sm leading-relaxed text-slate-500'>


### PR DESCRIPTION
## What
Nav + footer wordmark: `aswin.dev` → `aswincloud` (white `aswin`, emerald `cloud`).

## Why
The redesign coined `aswin.dev` as a stylistic wordmark, but the real domain, email, and self-hosted services are all `aswincloud.com`. `.dev` read as a placeholder pointing at a domain that isn't ours — someone would eventually try to visit it. `aswincloud` matches the real brand and reinforces the "I run my own cloud" theme the site already tells. It's cosmetic text (not a link), so nothing resolved — or now resolves — to a wrong domain.

## Verification
- Renders `aswin` (white) + `cloud` (accent) in both nav and footer.
- ESLint 0 warnings · Prettier clean · copyright valid · 4/4 unit tests · 0 vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)