### PR TITLE
chore: point résumé link at resume.aswincloud.com

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -172,7 +172,7 @@ const Navigation = React.memo(function Navigation() {
                   rel='noopener noreferrer'
                   className='mt-2 flex items-center rounded-lg border border-brand-500/40 bg-brand-500/10 px-4 py-3 font-mono text-sm font-medium text-brand-300'
                 >
-                  Download Résumé
+                  View Résumé
                 </a>
               </div>
             </motion.div>

--- a/src/components/sections/HeroSection.jsx
+++ b/src/components/sections/HeroSection.jsx
@@ -150,7 +150,7 @@ const HeroSection = React.memo(function HeroSection() {
                 whileHover={variants.buttonHover}
                 whileTap={variants.buttonTap}
                 className='group inline-flex w-full items-center justify-center gap-2 rounded-xl border border-hairline bg-surface/60 px-5 py-3.5 font-semibold text-slate-200 backdrop-blur-sm transition-colors hover:border-slate-600 hover:bg-surface sm:w-auto sm:px-7'
-                aria-label='Download résumé (PDF, opens in a new tab)'
+                aria-label='View résumé (opens in a new tab)'
               >
                 <FileText size={18} />
                 <span>Résumé</span>

--- a/src/data/links.js
+++ b/src/data/links.js
@@ -5,8 +5,6 @@
  * @description Shared external links — single source of truth so URLs don't drift across components
  */
 
-// Résumé PDF. The GitHub Releases `latest/download` path always resolves to the
-// newest published release, so this never needs a code change when a new
-// résumé build is cut.
-export const RESUME_URL =
-  'https://github.com/Aswincloud/resume/releases/latest/download/Aswin_Resume.pdf';
+// Résumé — served from a dedicated self-hosted subdomain so the link stays
+// stable and the underlying PDF can be updated without a code change.
+export const RESUME_URL = 'https://resume.aswincloud.com';


### PR DESCRIPTION
## What
Repoints the résumé link to the self-hosted **resume.aswincloud.com** subdomain.

- `RESUME_URL` in `src/data/links.js` (single source of truth) → `https://resume.aswincloud.com`; Nav, Hero, and Footer all pick it up automatically.
- That endpoint serves an **HTML résumé page** (`content-type: text/html`), not a PDF download — verified with `curl`. So the old "Download … (PDF)" wording was now inaccurate:
  - Hero button `aria-label`: "Download résumé (PDF, opens in a new tab)" → **"View résumé (opens in a new tab)"**
  - Mobile-menu link text: "Download Résumé" → **"View Résumé"**

## Verification
- Built bundle contains `resume.aswincloud.com`; the old GitHub Releases URL appears **0×**.
- Target returns HTTP 200.
- ESLint 0 warnings · Prettier clean · copyright valid · 4/4 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)