### PR TITLE
feat(hero): shimmer sweep on headline + perceptible aurora motion

### DIFF
--- a/src/components/background/AnimatedMeshGradient.jsx
+++ b/src/components/background/AnimatedMeshGradient.jsx
@@ -16,12 +16,15 @@ const AnimatedMeshGradient = () => {
       {/* Dotted engineering grid */}
       <div className='absolute inset-0 grid-bg opacity-70' />
 
-      {/* Aurora glow — emerald */}
+      {/* Aurora glow — emerald. Opacities and drift are tuned so the motion is
+          actually perceptible: a large, softly-blurred glow needs a strong
+          enough tint and a wide enough travel (see the aurora keyframe) to read
+          as "breathing" rather than sitting still. */}
       <div
         className='absolute -top-32 -left-24 h-[42rem] w-[42rem] rounded-full animate-aurora'
         style={{
-          background: 'radial-gradient(circle, rgba(16,185,129,0.20) 0%, transparent 62%)',
-          filter: 'blur(40px)',
+          background: 'radial-gradient(circle, rgba(16,185,129,0.30) 0%, transparent 62%)',
+          filter: 'blur(36px)',
         }}
       />
 
@@ -29,9 +32,9 @@ const AnimatedMeshGradient = () => {
       <div
         className='absolute top-10 right-[-8rem] h-[40rem] w-[40rem] rounded-full animate-aurora'
         style={{
-          background: 'radial-gradient(circle, rgba(34,211,238,0.16) 0%, transparent 62%)',
-          filter: 'blur(48px)',
-          animationDelay: '-8s',
+          background: 'radial-gradient(circle, rgba(34,211,238,0.24) 0%, transparent 62%)',
+          filter: 'blur(44px)',
+          animationDelay: '-5s',
         }}
       />
 
@@ -39,9 +42,9 @@ const AnimatedMeshGradient = () => {
       <div
         className='absolute bottom-[-14rem] left-1/3 h-[36rem] w-[36rem] rounded-full animate-aurora'
         style={{
-          background: 'radial-gradient(circle, rgba(99,102,241,0.14) 0%, transparent 65%)',
-          filter: 'blur(56px)',
-          animationDelay: '-16s',
+          background: 'radial-gradient(circle, rgba(99,102,241,0.20) 0%, transparent 65%)',
+          filter: 'blur(52px)',
+          animationDelay: '-10s',
         }}
       />
 

--- a/src/components/sections/HeroSection.jsx
+++ b/src/components/sections/HeroSection.jsx
@@ -104,7 +104,7 @@ const HeroSection = React.memo(function HeroSection() {
           >
             I make AI accelerators
             <br />
-            go <span className='gradient-text'>faster</span>.
+            go <span className='gradient-text-shimmer'>faster</span>.
           </motion.h1>
 
           {/* Sub copy */}

--- a/src/index.css
+++ b/src/index.css
@@ -34,9 +34,10 @@
   --font-display: 'Space Grotesk', Inter, system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
 
-  --animate-aurora: aurora 24s ease-in-out infinite;
+  --animate-aurora: aurora 16s ease-in-out infinite;
   --animate-marquee: marquee 40s linear infinite;
   --animate-pulse-slow: pulseSlow 3s ease-in-out infinite;
+  --animate-text-shimmer: textShimmer 6s ease-in-out infinite;
 
   @keyframes aurora {
     0%,
@@ -44,10 +45,10 @@
       transform: translate3d(0, 0, 0) scale(1);
     }
     33% {
-      transform: translate3d(6%, -4%, 0) scale(1.1);
+      transform: translate3d(12%, -8%, 0) scale(1.15);
     }
     66% {
-      transform: translate3d(-5%, 5%, 0) scale(0.95);
+      transform: translate3d(-10%, 10%, 0) scale(0.9);
     }
   }
   @keyframes marquee {
@@ -65,6 +66,19 @@
     }
     50% {
       opacity: 0.45;
+    }
+  }
+  /* A highlight glint sweeps left→right across a gradient text fill, then
+     rests off-screen for most of the cycle. Drives background-position, so it
+     only shows on an element whose background is oversized (see the utility). */
+  @keyframes textShimmer {
+    0%,
+    45%,
+    100% {
+      background-position: 150% 0;
+    }
+    70% {
+      background-position: -50% 0;
     }
   }
 }
@@ -157,6 +171,29 @@
 
 @utility gradient-text {
   @apply bg-linear-to-r from-brand-300 via-emerald-200 to-cyan-300 bg-clip-text text-transparent;
+}
+
+/* Living variant of gradient-text: same emerald→cyan fill, plus a soft white
+   highlight band that sweeps across every few seconds. The band is baked into
+   an oversized (200%) background so animating background-position slides it
+   through; at rest it parks off the right edge and reads identically to
+   gradient-text. Reserved for the hero headline so it stays a single accent. */
+@utility gradient-text-shimmer {
+  background-image: linear-gradient(
+    110deg,
+    #6ee7b7 0%,
+    #6ee7b7 30%,
+    #ffffff 45%,
+    #a7f3d0 55%,
+    #67e8f9 75%,
+    #67e8f9 100%
+  );
+  background-size: 200% 100%;
+  background-position: 150% 0;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  animation: var(--animate-text-shimmer);
 }
 
 /* Faint dotted-grid texture for section backgrounds. */


### PR DESCRIPTION
## What & why

You flagged that the hero looked static — and you were right. The background aurora *did* animate (a 24s drift), but at that speed + opacity + blur radius the movement was below the threshold the eye can catch, so it read as frozen. And the emerald→cyan **"faster"** was a flat gradient. Net: no ambient motion anyone could actually see.

This adds two on-brand, visible-but-calm motions:

### 1. Shimmer sweep on the headline
A new `gradient-text-shimmer` utility keeps the same emerald→cyan text fill but sweeps a soft **white highlight band** across it every ~6s, then parks off-edge (so between passes it's identical to the old `gradient-text`). Applied **only** to the hero "faster" — the other five `gradient-text` headings (About/Skills/Stack/Contact/404) are untouched, so it stays a single signature accent.

### 2. Perceptible aurora
The three background glows now:
- **+~50% opacity** (0.20/0.16/0.14 → 0.30/0.24/0.20)
- **tighter blur** (40/48/56px → 36/44/52px)
- **wider drift** (6% → 12% travel, scale 0.9–1.15)
- **faster** (24s → 16s) with re-staggered delays

so the backdrop visibly breathes instead of sitting still.

## Accessibility
Both inherit the existing global `prefers-reduced-motion` kill-switch in `index.css`, so they collapse to static when the user asks for reduced motion. No layout shift (shimmer animates `background-position`; aurora animates `transform` only).

## Verification
- Headless (Playwright) on the local nginx preview: confirmed the white glint sweeps across "faster" mid-cycle and returns to the plain gradient at rest; aurora now moves ~17px + scales 0.033 over 3s (was imperceptible).
- Ship-gate green locally: lint (0 warnings), `prettier --check .`, copyright (strict), vitest 4/4, `npm audit` 0 vulns, build.

Files: `src/index.css` (keyframe + utility + aurora tuning), `src/components/sections/HeroSection.jsx` (1-line class swap), `src/components/background/AnimatedMeshGradient.jsx` (glow params).

🤖 Generated with [Claude Code](https://claude.com/claude-code)