### PR TITLE
fix(chatwoot): close the chat panel on outside click

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,18 +144,19 @@
 
       // Close widget on outside click. The chat panel renders in its own iframe,
       // so clicks inside it never bubble here — any click we see is outside by
-      // definition. We just need to exclude the bubble itself so we don't fight
-      // its own toggle handler.
+      // definition. We just need to (a) act only while the panel is open and
+      // (b) exclude the bubble itself so we don't fight its own toggle handler.
+      //
+      // Open-state is read from the panel holder (#cw-widget-holder): Chatwoot
+      // adds the `woot--hide` class when closed and removes it when open. (An
+      // earlier `.woot-widget-bubble--expanded` selector never matched in this
+      // SDK version, so outside-click close silently never fired.)
       document.addEventListener('click', function (e) {
         if (!window.$chatwoot) return;
-        if (
-          !document.querySelector(
-            '.woot-widget-bubble--expanded, .woot--bubble-holder.woot-widget-bubble--expanded'
-          )
-        )
-          return;
-        var bubble = document.querySelector('.woot-widget-bubble, #cw-bubble-holder');
-        if (bubble && bubble.contains(e.target)) return;
+        var holder = document.querySelector('#cw-widget-holder, .woot-widget-holder');
+        if (!holder || holder.classList.contains('woot--hide')) return; // panel not open
+        var bubble = document.querySelector('#cw-bubble-holder, .woot-widget-bubble');
+        if (bubble && bubble.contains(e.target)) return; // let the bubble toggle itself
         window.$chatwoot.toggle('close');
       });
     </script>


### PR DESCRIPTION
## Problem

Opening the Chatwoot chat widget left it stuck open — clicking anywhere outside the panel didn't close it. You had to click the bubble again to dismiss it.

## Root cause

An outside-click handler already existed in `index.html`, but its open-state guard keyed off `.woot-widget-bubble--expanded` — **a class that doesn't exist in the running Chatwoot SDK version.** So the guard's `if (!expanded) return;` fired on every click and the close call was never reached.

Confirmed by inspecting the live widget DOM on the preview:

| state | `#cw-widget-holder` classes |
|-------|------------------------------|
| closed | `woot-widget-holder woot--hide woot-elements--right` |
| open | `woot-widget-holder woot-elements--right` |

`.woot-widget-bubble--expanded` matched in **neither** state.

## Fix

Read open-state from the panel holder instead: Chatwoot adds `woot--hide` to `#cw-widget-holder` when closed and removes it when open. The handler now:
1. runs only while the panel is open (`!holder.classList.contains('woot--hide')`),
2. still excludes the bubble itself so we don't fight its own toggle,
3. calls `$chatwoot.toggle('close')`.

The chat panel renders in its own iframe, so clicks inside it never bubble to this document handler — any click we see is genuinely outside.

## Verification (Playwright, on the local preview)
- initial → holder `hidden:true` (closed)
- `toggle('open')` → `hidden:false` (open)
- **click page background → `hidden:true` (closes ← the bug)**
- re-open → `hidden:false` (opens normally; handler doesn't over-fire)

Ship-gate green locally: `prettier --check .` (index.html included), lint (0 warnings), vitest 4/4, `npm audit` 0 vulns, build.

One-file change: `index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)