### PR TITLE
fix(deps): lucide-react 0.577 → 1.24 + replace removed brand icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aswin-portfolio",
       "version": "0.0.0",
       "dependencies": {
-        "lucide-react": "^0.577.0",
+        "lucide-react": "^1.24.0",
         "motion": "^12.40.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -4379,9 +4379,10 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.577.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
-      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.24.0.tgz",
+      "integrity": "sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==",
+      "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
-    "lucide-react": "^0.577.0",
+    "lucide-react": "^1.24.0",
     "motion": "^12.40.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/src/components/icons/BrandIcons.jsx
+++ b/src/components/icons/BrandIcons.jsx
@@ -1,0 +1,43 @@
+/**
+ * @file BrandIcons.jsx
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Brand/logo glyphs (GitHub, LinkedIn) as inline SVG components.
+ *   lucide-react removed all brand icons in v1 (trademark policy), so these
+ *   stand in with the same call signature the code already used — a `size`
+ *   prop and `className`, rendering in `currentColor` — making them drop-in
+ *   replacements for the former `lucide-react` imports. Filled marks (brand
+ *   logos are conventionally solid, unlike lucide's stroked UI icons).
+ */
+
+import React from 'react';
+
+// Shared wrapper: mirrors lucide's sizing/props API (numeric `size` → width &
+// height, currentColor fill, aria-hidden since the parent link carries the
+// label). Any extra props (e.g. style) are forwarded.
+const BrandSvg = ({ size = 24, className, children, ...props }) => (
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    width={size}
+    height={size}
+    viewBox='0 0 24 24'
+    fill='currentColor'
+    aria-hidden='true'
+    className={className}
+    {...props}
+  >
+    {children}
+  </svg>
+);
+
+export const Github = props => (
+  <BrandSvg {...props}>
+    <path d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12' />
+  </BrandSvg>
+);
+
+export const Linkedin = props => (
+  <BrandSvg {...props}>
+    <path d='M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z' />
+  </BrandSvg>
+);

--- a/src/components/sections/Footer.jsx
+++ b/src/components/sections/Footer.jsx
@@ -8,7 +8,8 @@
 
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Mail, Linkedin, Github, Terminal, ArrowUp } from 'lucide-react';
+import { Mail, Terminal, ArrowUp } from 'lucide-react';
+import { Github, Linkedin } from '../icons/BrandIcons.jsx';
 import { RESUME_URL } from '../../data/links.js';
 
 const LINKS = [

--- a/src/components/sections/HeroSection.jsx
+++ b/src/components/sections/HeroSection.jsx
@@ -9,15 +9,8 @@
 import React, { useState, useRef } from 'react';
 import { motion } from 'motion/react';
 import { useInView } from 'react-intersection-observer';
-import {
-  Github,
-  Linkedin,
-  Mail,
-  ArrowRight,
-  FileText,
-  ArrowDown,
-  MessageCircle,
-} from 'lucide-react';
+import { Mail, ArrowRight, FileText, ArrowDown, MessageCircle } from 'lucide-react';
+import { Github, Linkedin } from '../icons/BrandIcons.jsx';
 import { useExperienceCalculator, useThrottledScroll, useRipple, useCountUp } from '../../hooks';
 import { AnimatedMeshGradient } from '../background';
 import { useMicroInteractions } from '../../utils/microInteractions';

--- a/src/components/sections/ProjectsSection.jsx
+++ b/src/components/sections/ProjectsSection.jsx
@@ -9,7 +9,8 @@
 import React, { useState, useId, useRef } from 'react';
 import { motion } from 'motion/react';
 import { useInView } from 'react-intersection-observer';
-import { ExternalLink, ChevronDown, Github, Package, Check } from 'lucide-react';
+import { ExternalLink, ChevronDown, Package, Check } from 'lucide-react';
+import { Github } from '../icons/BrandIcons.jsx';
 import { featuredProjects, allProjects } from '../../data/projects.jsx';
 import { useRipple } from '../../hooks';
 


### PR DESCRIPTION
Supersedes #142 (Dependabot's plain version bump, which broke the build).

## Why #142 failed
lucide-react v1 **removed all brand/logo icons** (GitHub, LinkedIn, etc.) for trademark reasons — with no rename. So `Github`/`Linkedin` are gone entirely and the build errored with `MISSING_EXPORT`. I checked every icon we import against the v1.24 exports: **only these 2 broke**; the other 44 lucide icons we use are unchanged.

## Fix
New `src/components/icons/BrandIcons.jsx` — small inline-SVG `Github` and `Linkedin` marks that keep lucide's call signature (numeric `size` prop, `className`, `currentColor`). So the existing usages are drop-in with only the import source changed:
- `<Github size={15} />` in ProjectsSection
- the `{ icon: Github }` / `{ icon: Linkedin }` social-list entries in HeroSection + Footer, rendered via `<social.icon size={...} />`

No call-site markup changes, no new dependency (official brand SVG paths, inline).

## Verification (Playwright, preview)
- Hero socials render correctly — GitHub octocat + LinkedIn "in" + Mail, real SVG paths, zero console errors.
- `npm run build` green against v1.24; lint (0 warnings), `prettier --check .`, copyright (incl. new file), vitest 4/4, `npm audit` 0 vulns.

Files: `package.json` / `package-lock.json` (lucide-react ^1.24.0), `src/components/icons/BrandIcons.jsx` (new), and import-source swaps in HeroSection / Footer / ProjectsSection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)