### PR TITLE
feat: skip link + main landmark, project metric chips, About "now" line, contact copy

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -189,13 +189,23 @@ const Layout = ({ children }) => {
 
   return (
     <div className='min-h-screen bg-ink text-slate-300'>
+      {/* Skip link — first focusable element on the page. Visually hidden until
+          focused, then anchors keyboard/screen-reader users straight to the
+          main content, past the nav. Pairs with the <main id> landmark below. */}
+      <a
+        href='#main-content'
+        className='sr-only rounded-lg bg-brand-500 px-4 py-2 font-medium text-ink focus-visible:not-sr-only focus-visible:fixed focus-visible:left-4 focus-visible:top-4 focus-visible:z-[100]'
+      >
+        Skip to content
+      </a>
+
       <ScrollProgress />
 
       <ErrorBoundary level='component' fallbackComponent='Navigation'>
         <Navigation />
       </ErrorBoundary>
 
-      {children}
+      <main id='main-content'>{children}</main>
     </div>
   );
 };

--- a/src/components/sections/AboutSection.jsx
+++ b/src/components/sections/AboutSection.jsx
@@ -89,6 +89,19 @@ const AboutSection = React.memo(() => {
               Where software meets <span className='gradient-text'>silicon</span>
             </h2>
 
+            {/* "Now" line — a live status echoing the hero's availability chip,
+                so the page opens with a current, specific signal of what I'm on. */}
+            <p className='mt-5 inline-flex items-center gap-2.5 font-mono text-sm text-slate-400'>
+              <span className='relative flex h-2 w-2'>
+                <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-brand-400 opacity-75' />
+                <span className='relative inline-flex h-2 w-2 rounded-full bg-brand-400' />
+              </span>
+              <span>
+                <span className='text-slate-500'>Currently</span> — profiling tensor ops on AI
+                silicon at MulticoreWare
+              </span>
+            </p>
+
             <div className='mt-8 space-y-6 border-l border-hairline pl-6'>
               {PARAGRAPHS.map((p, i) => (
                 <motion.p

--- a/src/components/sections/ContactSection.jsx
+++ b/src/components/sections/ContactSection.jsx
@@ -145,7 +145,7 @@ const ContactSection = () => {
             Let&apos;s <span className='gradient-text'>work</span> together
           </h2>
           <p className='mt-4 text-lg leading-relaxed text-slate-400'>
-            Have a performance problem, a project, or just want to talk shop? Drop me a line.
+            Have a project, a performance problem, or just want to talk shop? Drop me a line.
           </p>
         </motion.div>
 

--- a/src/components/sections/ProjectsSection.jsx
+++ b/src/components/sections/ProjectsSection.jsx
@@ -22,15 +22,24 @@ const ProjectCard = ({ project, index, inView }) => {
       transition={{ duration: 0.55, delay: (index % 3) * 0.08 }}
       className='group relative flex h-full flex-col card-surface p-7 transition-colors duration-300 hover:border-slate-600 hover:bg-surface-2 lg:p-8'
     >
-      {/* Top row: icon + status */}
+      {/* Top row: icon + status/metric. The status pill states it's live; the
+          metric chip below gives each card a distinct at-a-glance signal so the
+          grid doesn't read as six identical "Live" badges. */}
       <div className='flex items-start justify-between gap-4'>
         <span className='flex h-14 w-14 items-center justify-center rounded-2xl border border-brand-500/20 bg-brand-500/10 text-brand-300 transition-transform duration-300 group-hover:scale-105 [&_svg]:h-7 [&_svg]:w-7'>
           {project.icon}
         </span>
-        <span className='inline-flex items-center gap-1.5 rounded-full border border-brand-500/20 bg-brand-500/10 px-2.5 py-1 font-mono text-[11px] font-medium text-brand-300'>
-          <span className='h-1.5 w-1.5 rounded-full bg-brand-400' />
-          {project.status}
-        </span>
+        <div className='flex flex-col items-end gap-1.5'>
+          <span className='inline-flex items-center gap-1.5 rounded-full border border-brand-500/20 bg-brand-500/10 px-2.5 py-1 font-mono text-[11px] font-medium text-brand-300'>
+            <span className='h-1.5 w-1.5 rounded-full bg-brand-400' />
+            {project.status}
+          </span>
+          {project.metric && (
+            <span className='rounded-full border border-hairline bg-surface-2 px-2.5 py-1 font-mono text-[11px] font-medium text-slate-400'>
+              {project.metric}
+            </span>
+          )}
+        </div>
       </div>
 
       {/* Title + domain */}

--- a/src/data/projects.jsx
+++ b/src/data/projects.jsx
@@ -19,6 +19,7 @@ export const featuredProjects = [
     link: 'https://www.aswincloud.com',
     repo: 'https://github.com/Aswincloud/portfolio',
     status: 'Live',
+    metric: 'Lighthouse 96+',
   },
   {
     id: 'ttperf',
@@ -39,6 +40,7 @@ export const featuredProjects = [
     repo: 'https://github.com/Aswincloud/ttperf',
     pypi: 'https://pypi.org/project/ttperf/',
     status: 'Live',
+    metric: 'On PyPI',
   },
   {
     id: 'ttnn-eltwise-performance',
@@ -58,6 +60,7 @@ export const featuredProjects = [
     link: 'https://ttnn-eltwise-performance.aswincloud.com',
     repo: 'https://github.com/Aswincloud/ttnn-performance-dashboard',
     status: 'Live',
+    metric: '13 op categories tracked',
   },
 ];
 
@@ -79,6 +82,7 @@ export const additionalProjects = [
     icon: <Brain size={48} />,
     link: 'https://pr-reviewer.aswincloud.com',
     status: 'Live',
+    metric: 'ML-powered',
   },
   {
     id: 'mirror-download-bot',
@@ -97,6 +101,7 @@ export const additionalProjects = [
     icon: <Zap size={48} />,
     link: 'https://t.me/Testdownload123bot',
     status: 'Live',
+    metric: 'Multi-source queue',
   },
   {
     id: 'word-chain-game-bot',
@@ -115,6 +120,7 @@ export const additionalProjects = [
     icon: <Gamepad2 size={48} />,
     link: 'https://t.me/gamebotbyashbot',
     status: 'Live',
+    metric: 'Multiplayer',
   },
 ];
 


### PR DESCRIPTION
Four small, grounded improvements from an audit of the live site (nothing invented — each fills a real gap I verified).

## 1. a11y — skip-to-content link + `<main>` landmark 🎯
There was **no skip link** (keyboard/screen-reader users had to tab through all 6 nav items + Résumé to reach content) and **no `<main>` landmark** at all. Added both:
- An `sr-only` "Skip to content" anchor — the first focusable element, appears on focus (verified: 1st Tab focuses it and it becomes visible), targeting…
- …a new `<main id="main-content">` wrapping the routed content.

Closes a real gap given the site already advertises "keyboard-accessible" as a feature.

## 2. Project metric chips 🏷️
All six cards showed an identical **"Live"** badge and nothing else. Added a per-project `metric` rendered as a subtle chip under the status pill:
`Lighthouse 96+` · `On PyPI` · `13 op categories tracked` · `ML-powered` · `Multi-source queue` · `Multiplayer`
Now each card has a distinct at-a-glance signal instead of six identical badges.

## 3. About "now" line 🟢
A live **"Currently — profiling tensor ops on AI silicon at MulticoreWare"** status under the About heading, echoing the hero's availability-chip motif (pulsing dot + mono), so the section opens with a specific, current signal.

## 4. Contact copy ✍️
The subheading led with *"Have a **performance problem**, a project…"* — a leftover of the old performance-only positioning. Reordered to *"Have a **project**, a performance problem…"* to match the broadened software-engineer + web-builds framing we've been aligning everything to.

## Verification (Playwright, preview)
- Skip link: 1st Tab → focused, visible, `href="#main-content"`; `<main id>` present. ✓
- Metric chips render distinctly (screenshotted the portfolio card: Live + Lighthouse 96+). ✓
- Now-line renders with the pulsing dot under the About heading. ✓
- Contact copy updated. ✓
- Ship-gate green: lint (0 warnings), `prettier --check .`, copyright strict, vitest 4/4, `npm audit` 0 vulns, build.

Files: `src/App.jsx` (skip link + main), `src/data/projects.jsx` + `ProjectsSection.jsx` (metrics), `AboutSection.jsx` (now-line), `ContactSection.jsx` (copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)