### PR TITLE
feat(blog): add extensible blog section + first post

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -64,4 +64,14 @@ export default [
       'no-unused-vars': 'off',
     },
   },
+  {
+    // Blog post modules intentionally co-locate a `meta` object with their
+    // `Body` component (that's the post-registry contract), so the fast-refresh
+    // "only export components" rule doesn't apply — these are content modules,
+    // not HMR-refreshed component files.
+    files: ['src/data/blog/**/*.jsx'],
+    rules: {
+      'react-refresh/only-export-components': 'off',
+    },
+  },
 ];

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -37,6 +37,18 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://www.aswincloud.com/blog</loc>
+    <lastmod>2026-07-16</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://www.aswincloud.com/blog/building-this-portfolio</loc>
+    <lastmod>2026-07-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
     <loc>https://www.aswincloud.com/privacy</loc>
     <lastmod>2026-05-26</lastmod>
     <changefreq>yearly</changefreq>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,6 +33,8 @@ import ScrollProgress from './components/ScrollProgress.jsx';
 // first-paint bundle. They load on demand when their route is hit.
 const PrivacyPolicy = lazy(() => import('./components/PrivacyPolicy.jsx'));
 const TermsConditions = lazy(() => import('./components/TermsConditions.jsx'));
+const BlogIndex = lazy(() => import('./components/blog/BlogIndex.jsx'));
+const BlogPost = lazy(() => import('./components/blog/BlogPost.jsx'));
 const NotFound = lazy(() => import('./components/NotFound.jsx'));
 
 const getBasename = () => import.meta.env.BASE_URL || '/';
@@ -247,6 +249,22 @@ const App = () => {
                     element={
                       <ErrorBoundary level='page' fallbackComponent='Terms & Conditions'>
                         <TermsConditions />
+                      </ErrorBoundary>
+                    }
+                  />
+                  <Route
+                    path='/blog'
+                    element={
+                      <ErrorBoundary level='page' fallbackComponent='Blog'>
+                        <BlogIndex />
+                      </ErrorBoundary>
+                    }
+                  />
+                  <Route
+                    path='/blog/:slug'
+                    element={
+                      <ErrorBoundary level='page' fallbackComponent='Blog Post'>
+                        <BlogPost />
                       </ErrorBoundary>
                     }
                   />

--- a/src/components/blog/BlogIndex.jsx
+++ b/src/components/blog/BlogIndex.jsx
@@ -1,0 +1,99 @@
+/**
+ * @file BlogIndex.jsx
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Blog listing page at /blog — a card per post, newest first.
+ */
+
+import React, { useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowLeft, ArrowRight, CalendarDays, Clock } from 'lucide-react';
+import { posts } from '../../data/blog/index.jsx';
+
+const formatDate = iso =>
+  new Date(`${iso}T00:00:00`).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+const BlogIndex = () => {
+  useEffect(() => {
+    document.title = 'Blog — Aswin';
+  }, []);
+
+  return (
+    <div className='min-h-screen bg-ink px-4 py-24 sm:px-6'>
+      <div className='mx-auto max-w-3xl'>
+        <Link
+          to='/'
+          viewTransition
+          className='inline-flex items-center gap-2 font-mono text-sm text-slate-500 transition-colors hover:text-brand-300'
+        >
+          <ArrowLeft size={15} />
+          Back home
+        </Link>
+
+        <header className='mt-8'>
+          <p className='eyebrow mb-4'>Writing</p>
+          <h1 className='text-4xl font-bold sm:text-5xl'>
+            The <span className='gradient-text'>blog</span>
+          </h1>
+          <p className='mt-4 text-lg leading-relaxed text-slate-400'>
+            Notes on what I build and how — performance, the web, and running my own cloud.
+          </p>
+        </header>
+
+        <ul className='mt-12 space-y-5'>
+          {posts.map(post => (
+            <li key={post.slug}>
+              <Link
+                to={`/blog/${post.slug}`}
+                viewTransition
+                className='group block card-surface p-6 transition-colors duration-300 hover:border-brand-500/30 hover:bg-surface-2 sm:p-7'
+              >
+                <div className='flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-xs text-slate-500'>
+                  <span className='inline-flex items-center gap-1.5'>
+                    <CalendarDays size={13} />
+                    {formatDate(post.date)}
+                  </span>
+                  <span className='inline-flex items-center gap-1.5'>
+                    <Clock size={13} />
+                    {post.readingTime}
+                  </span>
+                </div>
+
+                <h2 className='mt-3 text-xl font-bold text-white transition-colors group-hover:text-brand-200 sm:text-2xl'>
+                  {post.title}
+                </h2>
+                <p className='mt-2 leading-relaxed text-slate-400'>{post.description}</p>
+
+                <div className='mt-4 flex flex-wrap items-center justify-between gap-3'>
+                  <div className='flex flex-wrap gap-2'>
+                    {post.tags.map(tag => (
+                      <span
+                        key={tag}
+                        className='rounded-md border border-hairline bg-surface-2 px-2.5 py-1 font-mono text-[11px] text-slate-400'
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                  <span className='inline-flex items-center gap-1.5 font-mono text-sm text-brand-300'>
+                    Read
+                    <ArrowRight
+                      size={15}
+                      className='transition-transform duration-200 group-hover:translate-x-0.5'
+                    />
+                  </span>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default BlogIndex;

--- a/src/components/blog/BlogPost.jsx
+++ b/src/components/blog/BlogPost.jsx
@@ -1,0 +1,106 @@
+/**
+ * @file BlogPost.jsx
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Single blog post page at /blog/:slug. Looks the post up in the
+ *   registry, renders its Body, and falls back to a not-found state for an
+ *   unknown slug. Sets the document title for the post.
+ */
+
+import React, { useEffect } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { ArrowLeft, CalendarDays, Clock } from 'lucide-react';
+import { getPost } from '../../data/blog/index.jsx';
+
+const formatDate = iso =>
+  new Date(`${iso}T00:00:00`).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+const BlogPost = () => {
+  const { slug } = useParams();
+  const post = getPost(slug);
+
+  useEffect(() => {
+    document.title = post ? `${post.title} — Aswin` : 'Post not found — Aswin';
+    window.scrollTo(0, 0);
+  }, [post]);
+
+  if (!post) {
+    return (
+      <div className='flex min-h-screen flex-col items-center justify-center bg-ink px-4 text-center'>
+        <p className='eyebrow mb-4'>404</p>
+        <h1 className='text-3xl font-bold sm:text-4xl'>That post doesn&apos;t exist</h1>
+        <p className='mt-3 text-slate-400'>The link may be broken or the post may have moved.</p>
+        <Link
+          to='/blog'
+          viewTransition
+          className='mt-8 inline-flex items-center gap-2 rounded-xl border border-hairline bg-surface px-5 py-3 font-medium text-slate-200 transition-colors hover:border-brand-500/40 hover:text-brand-200'
+        >
+          <ArrowLeft size={16} />
+          All posts
+        </Link>
+      </div>
+    );
+  }
+
+  const { Body } = post;
+
+  return (
+    <div className='min-h-screen bg-ink px-4 py-24 sm:px-6'>
+      <article className='mx-auto max-w-3xl'>
+        <Link
+          to='/blog'
+          viewTransition
+          className='inline-flex items-center gap-2 font-mono text-sm text-slate-500 transition-colors hover:text-brand-300'
+        >
+          <ArrowLeft size={15} />
+          All posts
+        </Link>
+
+        <header className='mt-8 border-b border-hairline pb-8'>
+          <div className='flex flex-wrap items-center gap-x-4 gap-y-1 font-mono text-xs text-slate-500'>
+            <span className='inline-flex items-center gap-1.5'>
+              <CalendarDays size={13} />
+              {formatDate(post.date)}
+            </span>
+            <span className='inline-flex items-center gap-1.5'>
+              <Clock size={13} />
+              {post.readingTime}
+            </span>
+          </div>
+          <h1 className='mt-4 text-3xl font-bold leading-tight sm:text-4xl'>{post.title}</h1>
+          <div className='mt-5 flex flex-wrap gap-2'>
+            {post.tags.map(tag => (
+              <span
+                key={tag}
+                className='rounded-md border border-hairline bg-surface-2 px-2.5 py-1 font-mono text-[11px] text-slate-400'
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </header>
+
+        <div className='mt-2'>
+          <Body />
+        </div>
+
+        <footer className='mt-16 border-t border-hairline pt-8'>
+          <Link
+            to='/blog'
+            viewTransition
+            className='inline-flex items-center gap-2 font-mono text-sm text-brand-300 transition-colors hover:text-brand-200'
+          >
+            <ArrowLeft size={15} />
+            Back to all posts
+          </Link>
+        </footer>
+      </article>
+    </div>
+  );
+};
+
+export default BlogPost;

--- a/src/components/blog/Prose.jsx
+++ b/src/components/blog/Prose.jsx
@@ -1,0 +1,63 @@
+/**
+ * @file Prose.jsx
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Styled prose primitives shared by every blog post, so posts are
+ *   authored as plain JSX (no markdown pipeline) while staying visually
+ *   consistent with the site's dark design system.
+ */
+
+import React from 'react';
+
+export const H2 = ({ children }) => (
+  <h2 className='mt-12 scroll-mt-24 text-2xl font-bold text-white sm:text-3xl'>{children}</h2>
+);
+
+export const H3 = ({ children }) => (
+  <h3 className='mt-8 text-lg font-semibold text-white sm:text-xl'>{children}</h3>
+);
+
+export const P = ({ children }) => (
+  <p className='mt-5 leading-relaxed text-slate-300'>{children}</p>
+);
+
+export const UL = ({ children }) => <ul className='mt-5 space-y-2.5 text-slate-300'>{children}</ul>;
+
+export const LI = ({ children }) => (
+  <li className='flex items-start gap-3 leading-relaxed'>
+    <span className='mt-2.5 h-1.5 w-1.5 shrink-0 rounded-full bg-brand-400' />
+    <span className='min-w-0'>{children}</span>
+  </li>
+);
+
+// Inline code / identifier.
+export const Code = ({ children }) => (
+  <code className='rounded bg-surface-2 px-1.5 py-0.5 font-mono text-[0.85em] text-brand-200'>
+    {children}
+  </code>
+);
+
+export const A = ({ href, children }) => (
+  <a
+    href={href}
+    target={href.startsWith('http') ? '_blank' : undefined}
+    rel={href.startsWith('http') ? 'noopener noreferrer' : undefined}
+    className='text-brand-300 underline decoration-brand-500/40 underline-offset-2 transition-colors hover:text-brand-200 hover:decoration-brand-400'
+  >
+    {children}
+  </a>
+);
+
+// A pulled-out aside — used for "lesson learned" beats.
+export const Callout = ({ children }) => (
+  <div className='mt-6 rounded-xl border border-brand-500/20 bg-brand-500/5 p-5 leading-relaxed text-slate-300'>
+    {children}
+  </div>
+);
+
+// A fenced code / terminal block.
+export const Pre = ({ children }) => (
+  <pre className='mt-5 overflow-x-auto rounded-xl border border-hairline bg-surface p-4 font-mono text-[13px] leading-relaxed text-slate-300'>
+    <code>{children}</code>
+  </pre>
+);

--- a/src/data/blog/building-this-portfolio.jsx
+++ b/src/data/blog/building-this-portfolio.jsx
@@ -1,0 +1,172 @@
+/**
+ * @file building-this-portfolio.jsx
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Blog post: how this portfolio was rebuilt — the real story of
+ *   pairing with an AI agent, the bugs, and the workflow that kept it honest.
+ */
+
+import React from 'react';
+import { H2, H3, P, UL, LI, Code, A, Callout } from '../../components/blog/Prose.jsx';
+
+export const meta = {
+  slug: 'building-this-portfolio',
+  title: 'How this portfolio actually got built',
+  description:
+    'The real story of rebuilding aswincloud.com — pairing with an AI coding agent, the bugs it caught (and caused), and the ship-gate workflow that kept it all honest.',
+  date: '2026-07-16',
+  readingTime: '8 min read',
+  tags: ['Portfolio', 'React', 'AI-assisted', 'Engineering'],
+};
+
+export const Body = () => (
+  <>
+    <P>
+      The site you are reading this on is the third or fourth version of my portfolio, and the first
+      one I am genuinely happy with. This post is the honest account of how it came together — not a
+      tidy after-the-fact narrative, but what actually happened: a lot of iteration, a few bugs I
+      caused, a couple the tooling caught before you ever saw them, and a workflow that kept the
+      whole thing from turning into a mess.
+    </P>
+    <P>
+      I built it pairing with <A href='https://claude.com/claude-code'>Claude Code</A>, an AI coding
+      agent, running in my terminal. I want to be upfront about that because the interesting part
+      isn&apos;t &quot;AI wrote my website&quot; — it didn&apos;t, not on its own — it&apos;s the
+      loop we settled into, where I made the calls and it did the legwork, and neither of us was
+      allowed to claim something worked without proving it.
+    </P>
+
+    <H2>The starting point: too plain</H2>
+    <P>
+      The previous version leaned hard into austere, editorial minimalism — lots of whitespace, thin
+      type, almost no color. On paper that reads as &quot;tasteful.&quot; In practice it read as
+      unfinished. So the brief for the rebuild was a dark, systems-engineer aesthetic: deep navy
+      canvas, an emerald-to-cyan accent, monospace for the technical labels, and just enough motion
+      to feel alive without tipping into a gimmick.
+    </P>
+    <P>
+      The design system is hand-built — no UI kit, no template. Everything is Tailwind CSS v4 with a
+      small set of custom tokens (<Code>--color-ink</Code>, <Code>--color-surface</Code>, a{' '}
+      <Code>brand-*</Code> emerald ramp) and a handful of <Code>@utility</Code> helpers so the class
+      names stay readable. React 19, Vite, Motion for animation, deployed to Cloudflare Workers with
+      a self-hosted contact API and live chat.
+    </P>
+
+    <H2>The motion I swore was already there (it wasn&apos;t)</H2>
+    <P>
+      Here is my favorite mistake from the whole build. The hero has an aurora background — three
+      big, soft glows drifting behind the headline. When I was asked whether the site had any live
+      animation, I checked the code, saw the drift keyframes were applied, and confidently said yes,
+      it&apos;s animating.
+    </P>
+    <P>
+      Then I actually looked. And it wasn&apos;t — not perceptibly. The glows <em>were</em> moving,
+      about 40 pixels over six seconds, but they are 670-pixel-wide blobs blurred by 40+ pixels at
+      very low opacity. A faint, heavily-blurred cloud that large drifting that slowly is below the
+      threshold your eye can register. The transform value was changing; nothing you could see was.
+    </P>
+    <Callout>
+      &quot;It animates&quot; and &quot;you can see it move&quot; are not the same claim. The first
+      is about the code; the second is about a human looking at a screen. On a portfolio, only the
+      second one counts.
+    </Callout>
+    <P>
+      So I fixed it for real: bumped the glow opacity, tightened the blur, widened the drift, and
+      sped the loop up so the background genuinely breathes. Then I added a shimmer that sweeps a
+      soft highlight across the word &quot;faster&quot; every few seconds, and — the detail people
+      seem to like most — the stat tiles now count up from zero when they scroll into view.
+    </P>
+
+    <H3>The count-up that counted too fast</H3>
+    <P>
+      That count-up shipped with a subtle bug I only caught because I was watching the real page.
+      The numbers started climbing the instant the component mounted, with an ease curve that
+      front-loads the motion — so by the time the tile finished fading in, the count was already
+      ~84% done. You&apos;d see <Code>9 → 10</Code> and nothing before it. The fix was to hold the
+      climb until the entrance animation finishes, then count at an even pace. Now you actually see{' '}
+      <Code>1, 2, 4, 6, 8, 10</Code> tick past.
+    </P>
+
+    <H2>The bug I&apos;d written and never noticed</H2>
+    <P>
+      The site has a live chat widget. Open it, and — as I discovered when someone pointed it out —
+      you couldn&apos;t click outside to close it. There was already an outside-click handler in the
+      page; it just never fired. It was checking for a CSS class (
+      <Code>.woot-widget-bubble--expanded</Code>) that doesn&apos;t exist in the version of the chat
+      SDK the site actually runs. So the guard bailed out on every click and the close never
+      happened.
+    </P>
+    <P>
+      I only found the true cause by inspecting the live widget&apos;s DOM instead of trusting the
+      class name I&apos;d assumed. The real open/closed signal was a <Code>woot--hide</Code> class
+      on a different element entirely. Two-line fix, but it would have stayed broken indefinitely if
+      I&apos;d kept reasoning from the class name I <em>expected</em> to be there.
+    </P>
+
+    <H2>Dependencies that don&apos;t just &quot;bump&quot;</H2>
+    <P>
+      Two dependency upgrades looked routine and weren&apos;t. The icon library removed all of its
+      brand logos in a major version (GitHub, LinkedIn — gone, for trademark reasons), so a plain
+      version bump broke the build with missing-export errors. The fix was to replace those two with
+      small inline-SVG components that keep the same call signature, so nothing else in the code had
+      to change.
+    </P>
+    <P>
+      The linter upgrade to ESLint 10 was worse: it required a newer hooks plugin that turns on
+      strict new rules by default, which flagged perfectly good code — including the count-up hook I
+      just described. There the right move wasn&apos;t to force it through or silently rewrite
+      working code; it was to surface the trade-off, then opt out of exactly the two new opinionated
+      rules while keeping the ones that catch real hook bugs.
+    </P>
+    <Callout>
+      A green CI check is necessary, not sufficient. A dependency can install clean, pass every
+      automated gate, and still be the wrong thing to merge — because &quot;it builds&quot; says
+      nothing about whether the API you rely on still exists.
+    </Callout>
+
+    <H2>The workflow that kept it honest</H2>
+    <P>
+      None of the above would have stayed sane without a boring, strict loop around every change:
+    </P>
+    <UL>
+      <LI>
+        <strong>Make the change, then prove it.</strong> Every visual change got built and driven in
+        a real headless browser — screenshotted, pixel-checked, the actual behavior observed. Not
+        &quot;the test passes,&quot; but &quot;here is the frame where the number is
+        mid-climb.&quot;
+      </LI>
+      <LI>
+        <strong>A ship-gate before anything merges.</strong> Lint with zero warnings allowed,
+        formatting, a copyright-header check, the unit tests, a security audit, and a production
+        build — all green, locally, before a pull request even opens.
+      </LI>
+      <LI>
+        <strong>One change, one PR.</strong> The shimmer, the chat fix, the perf pass, the
+        accessibility pass — each is its own small, reviewable pull request rather than one giant
+        &quot;redesign&quot; commit. Easier to review, easier to revert, easier to explain.
+      </LI>
+      <LI>
+        <strong>Correct the record when wrong.</strong> The aurora story is the template: claim,
+        check, discover the claim was wrong, say so, fix it. That only works if being wrong is cheap
+        and admitting it is normal.
+      </LI>
+    </UL>
+
+    <H2>What I&apos;d tell you about pairing with an agent</H2>
+    <P>
+      The useful mental model isn&apos;t &quot;the AI builds it for me.&quot; It&apos;s closer to
+      working with a very fast, very literal collaborator who will happily do the tedious parts —
+      wire up the component, run the build, drive the browser, open the PR — but who needs a human
+      to make the judgment calls and to insist on proof. The moments that mattered most were the
+      ones where I said &quot;I don&apos;t see it&quot; or &quot;that dependency looks risky, check
+      it first&quot; — human taste and skepticism pointed at a tool that could then do the
+      verification work at a pace I couldn&apos;t.
+    </P>
+    <P>
+      The result is a site I can stand behind line by line — because every line got looked at,
+      built, and driven before it shipped. If you found a bug anyway,{' '}
+      <A href='mailto:contact@aswincloud.com'>tell me</A> — that&apos;s the next entry in this same
+      loop.
+    </P>
+  </>
+);

--- a/src/data/blog/index.jsx
+++ b/src/data/blog/index.jsx
@@ -1,0 +1,19 @@
+/**
+ * @file index.jsx
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Blog post registry. Each post is a module exporting `meta`
+ *   (slug, title, description, date, readingTime, tags) and a default `Body`
+ *   component. To add a post: create a new module under this folder and add it
+ *   to POSTS below — the index page and routing pick it up automatically.
+ */
+
+import {
+  meta as buildingThisPortfolioMeta,
+  Body as BuildingThisPortfolioBody,
+} from './building-this-portfolio.jsx';
+
+// Newest first — this order is what the /blog index renders.
+export const posts = [{ ...buildingThisPortfolioMeta, Body: BuildingThisPortfolioBody }];
+
+export const getPost = slug => posts.find(p => p.slug === slug) || null;


### PR DESCRIPTION
## What

Adds a self-contained **blog** to the portfolio at `/blog` (listing) and `/blog/:slug` (post), plus the first post.

Built on a tiny **post registry** so adding a post later is one new module + one line in `src/data/blog/index.jsx` — no markdown pipeline, no new dependencies, everything renders through on-brand styled components.

## First post

**How this portfolio actually got built** — an honest, first-person account of rebuilding the site while pairing with an AI coding agent: the aurora that wasn't really animating, the count-up timing bug, the Chatwoot outside-click bug, the dependency upgrades that weren't routine (brand-icon removal, ESLint 10), and the ship-gate workflow that kept it all honest.

Per the agreed scope, the blog is **unlinked from the nav for now** — reachable by URL and listed in the sitemap.

## Changes

- `src/data/blog/` — registry (`index.jsx`) + first post module (`building-this-portfolio.jsx`), each exporting `meta` + a `Body` component.
- `src/components/blog/` — `Prose.jsx` (styled prose elements, dark design system), `BlogIndex.jsx` (listing), `BlogPost.jsx` (single post; 404 state for unknown slugs; sets `document.title`).
- `src/App.jsx` — lazy-loaded `/blog` and `/blog/:slug` routes, each wrapped in a page-level `ErrorBoundary`, before the catch-all.
- `public/sitemap.xml` — `/blog` + the first post entry.
- `eslint.config.js` — scope off `react-refresh/only-export-components` for `src/data/blog/**` (post modules intentionally co-locate `meta` with their `Body` — that's the registry contract, not an HMR component file).

## Verification

- Ship-gate green locally: lint (0 warnings), `prettier --check` (whole repo), copyright headers, `vitest` (4/4), `npm audit` (0 vulns), production build.
- Full flow driven in a headless browser on the preview container: index page (title, cards), post render (headings/paragraphs/callouts, on-brand styling), unknown-slug 404 state, and deep-link — 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)