### PR TITLE
fix(deps): patch audit gate — js-yaml ^4.3.0, brace-expansion ^1.1.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1974,10 +1974,11 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3854,9 +3855,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -3868,6 +3869,7 @@
           "url": "https://github.com/sponsors/nodeca"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
   },
   "overrides": {
     "@babel/core": "^7.29.1",
-    "js-yaml": "^4.1.2"
+    "js-yaml": "^4.3.0",
+    "brace-expansion": "^1.1.16"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [


### PR DESCRIPTION
## Why
The required **🔒 Security** check (`npm audit --audit-level=moderate`) was failing on **every open PR** — two new high-severity advisories landed on `main`, unrelated to any dependabot diff. Because `main`'s merge queue requires Security to be green, **nothing could merge** until this is fixed.

## Advisories cleared
- **js-yaml** `4.0.0–4.2.0` — YAML merge-key chains → quadratic CPU ([GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m)). The pre-existing override `^4.1.2` had fallen *inside* the advisory range → bumped to `^4.3.0` (staying on 4.x; 5.x is a major).
- **brace-expansion** `<1.1.16` — DoS via exponential `{}` expansion ([GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp)). Added override `^1.1.16` (single 1.x instance in the tree, no major-version collision).

## Verification
```
$ npm run security:check
found 0 vulnerabilities   (exit 0)
```
Only `package.json` + `package-lock.json` change. Unblocks the merge queue for the 7 remaining open PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)