### PR TITLE
fix(api): harden /api/contact against abuse and stop logging visitor PII

### DIFF
--- a/e2e/honeypot.spec.js
+++ b/e2e/honeypot.spec.js
@@ -1,0 +1,84 @@
+/**
+ * @file honeypot.spec.js
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @author Aswin
+ * @description Browser checks for the contact-form honeypot.
+ *
+ * The unit tests assert on attributes; only a real browser can confirm the field is
+ * actually off-screen and does not affect layout. If the honeypot ever became visible
+ * it would look like a bug to visitors, and if it moved into the viewport a real person
+ * could fill it in and have their message silently dropped.
+ */
+import { test, expect } from '@playwright/test';
+
+const HONEYPOT = 'input[name="company"]';
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  await page.locator('#contact').scrollIntoViewIfNeeded();
+  await page.locator('#contact-name').waitFor({ state: 'visible' });
+});
+
+test('honeypot exists in the DOM so bots can find it', async ({ page }) => {
+  await expect(page.locator(HONEYPOT)).toHaveCount(1);
+});
+
+test('honeypot is entirely off-screen, not merely covered', async ({ page }) => {
+  // Deliberately not `toBeHidden()`: Playwright treats an off-screen element with a
+  // bounding box as "visible", and it would equally accept a field hidden under an
+  // opaque overlay — which a visitor could still reach. Assert on real geometry instead.
+  const box = await page.locator(HONEYPOT).boundingBox();
+  expect(box).not.toBeNull();
+  expect(box.x + box.width).toBeLessThan(0);
+});
+
+test('honeypot does not create a horizontal scrollbar', async ({ page }) => {
+  // The classic failure of the -9999px technique: the off-screen field widens the
+  // document and every page gains a horizontal scrollbar.
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+  );
+  expect(overflow).toBeLessThanOrEqual(0);
+});
+
+test('honeypot wrapper occupies no layout space', async ({ page }) => {
+  // If the wrapper stopped being absolutely positioned and zero-sized it would push
+  // the real fields down — visible breakage rather than a silent one.
+  const wrapper = await page.evaluate(() => {
+    const r = document.querySelector('input[name="company"]').parentElement.getBoundingClientRect();
+    return { width: r.width, height: r.height };
+  });
+  expect(wrapper.width).toBe(0);
+  expect(wrapper.height).toBe(0);
+});
+
+test('tabbing through the form never lands on the honeypot', async ({ page }) => {
+  await page.locator('#contact-name').focus();
+  for (let i = 0; i < 10; i += 1) {
+    await page.keyboard.press('Tab');
+    const focusedName = await page.evaluate(() => document.activeElement?.getAttribute('name'));
+    expect(focusedName).not.toBe('company');
+  }
+});
+
+test('a genuine submission posts the honeypot empty', async ({ page }) => {
+  let posted = null;
+  await page.route('**/api/contact', async route => {
+    posted = JSON.parse(route.request().postData() || '{}');
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ success: true, message: 'ok' }),
+    });
+  });
+
+  await page.locator('#contact-name').fill('Jane Doe');
+  await page.locator('#contact-email').fill('jane@example.com');
+  await page.locator('#contact-message').fill('Hello, I would like to discuss a project.');
+  await page.getByRole('button', { name: /send contact message/i }).click();
+
+  await expect(page.getByText(/message sent successfully/i)).toBeVisible();
+  expect(posted).not.toBeNull();
+  expect(posted.company).toBe('');
+  expect(posted.name).toBe('Jane Doe');
+});

--- a/src/__tests__/contactApi.test.js
+++ b/src/__tests__/contactApi.test.js
@@ -1,0 +1,469 @@
+/**
+ * @file contactApi.test.js
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Tests for the hardening applied to POST /api/contact.
+ *
+ * These exercise the Worker's exported helpers and route handler directly against
+ * real Request/Response objects. The point of each test is a specific attack or
+ * leak the hardening exists to stop, so a regression fails loudly rather than
+ * quietly widening the endpoint again.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  ALLOWED_ORIGIN_PATTERNS,
+  LIMITS,
+  escapeHtml,
+  redactEmail,
+  resolveAllowedOrigin,
+  createEmailHTML,
+  createAutoReplyHTML,
+  handleApiRoutes,
+  handleContactForm,
+} from '../../worker.js';
+
+/**
+ * Stub the Resend call for every test in this file.
+ *
+ * A submission that clears validation calls fetch('https://api.resend.com/emails'),
+ * so without this the suite makes real outbound requests — which is slow, flaky, and
+ * (with a real key in the environment) would send mail. The stub is installed globally
+ * rather than per-test so a future test that forgets cannot silently start doing I/O;
+ * `fetchMock` is available to assert on where nothing should have been sent.
+ */
+let fetchMock;
+beforeEach(() => {
+  fetchMock = vi
+    .spyOn(globalThis, 'fetch')
+    .mockResolvedValue(new Response(JSON.stringify({ id: 'stub-email-id' }), { status: 200 }));
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Silence the Worker's console output for tests that don't assert on it. */
+const muteLogs = () => {
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+};
+
+/** A Worker-shaped env with a rate limiter that always allows. */
+const allowingEnv = () => ({
+  CONTACT_RATE_LIMIT: { limit: vi.fn(async () => ({ success: true })) },
+});
+
+/** A Worker-shaped env with a rate limiter that always denies. */
+const denyingEnv = () => ({
+  CONTACT_RATE_LIMIT: { limit: vi.fn(async () => ({ success: false })) },
+});
+
+const contactRequest = (body, headers = {}) =>
+  new Request('https://aswincloud.com/api/contact', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+
+const validSubmission = {
+  name: 'Jane Doe',
+  email: 'jane@example.com',
+  message: 'Hello, I would like to talk about a project.',
+};
+
+describe('escapeHtml', () => {
+  it('neutralises the characters that can open a tag or escape an attribute', () => {
+    expect(escapeHtml('<script>alert(1)</script>')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(escapeHtml(`" onmouseover='x'`)).toBe('&quot; onmouseover=&#39;x&#39;');
+  });
+
+  it('escapes & first so existing entities cannot be reconstructed', () => {
+    // If & were escaped last, `&lt;` typed by a visitor would survive as a real
+    // tag delimiter after the other replacements ran.
+    expect(escapeHtml('&lt;img&gt;')).toBe('&amp;lt;img&amp;gt;');
+  });
+
+  it('coerces non-strings rather than throwing', () => {
+    expect(escapeHtml(undefined)).toBe('undefined');
+    expect(escapeHtml(42)).toBe('42');
+  });
+});
+
+describe('createEmailHTML', () => {
+  it('does not emit visitor markup as live HTML', () => {
+    const html = createEmailHTML(
+      '<b>Bold</b>',
+      'attacker@example.com',
+      '<img src=x onerror=alert(1)>'
+    );
+    expect(html).not.toContain('<b>Bold</b>');
+    expect(html).not.toContain('<img src=x');
+    expect(html).toContain('&lt;b&gt;Bold&lt;/b&gt;');
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+  });
+
+  it('percent-encodes the address in mailto: hrefs so extra headers cannot be injected', () => {
+    // A bare escapeHtml would leave `?` and `&` intact, letting the address smuggle
+    // a bcc/cc into the reply link that the recipient would send on a single click.
+    const html = createEmailHTML(
+      'Jane',
+      'jane@example.com?bcc=leak@evil.example',
+      'A perfectly normal message body.'
+    );
+    expect(html).not.toMatch(/href="mailto:[^"]*\?bcc=/);
+    expect(html).toContain('%3Fbcc%3Dleak%40evil.example');
+  });
+
+  it('keeps intended line breaks while escaping the surrounding text', () => {
+    const html = createEmailHTML('Jane', 'jane@example.com', 'line one\n<b>line two</b>');
+    expect(html).toContain('line one<br>&lt;b&gt;line two&lt;/b&gt;');
+  });
+});
+
+describe('createAutoReplyHTML', () => {
+  it('escapes the name in a message delivered to an address the caller chose', () => {
+    const html = createAutoReplyHTML('<script>x</script>', 'A normal message body here.');
+    expect(html).not.toContain('<script>x</script>');
+    expect(html).toContain('&lt;script&gt;x&lt;/script&gt;');
+  });
+
+  it('truncates before escaping so an entity is never cut in half', () => {
+    // 99 chars, then a character that expands to a 5-char entity. Truncating after
+    // escaping would slice `&quot;` mid-entity and emit `&quo` as literal text.
+    const message = `${'a'.repeat(99)}"tail`;
+    const html = createAutoReplyHTML('Jane', message);
+    expect(html).toContain(`${'a'.repeat(99)}&quot;...`);
+    expect(html).not.toMatch(/&quo[^t]/);
+  });
+
+  it('leaves short messages unabridged', () => {
+    const html = createAutoReplyHTML('Jane', 'Short message.');
+    expect(html).toContain('Short message.');
+    expect(html).not.toContain('...');
+  });
+});
+
+describe('redactEmail', () => {
+  it('keeps the domain and shape but not the local part', () => {
+    expect(redactEmail('someone@example.com')).toBe('s*****e@example.com');
+  });
+
+  it('handles local parts too short to partially mask', () => {
+    expect(redactEmail('ab@example.com')).toBe('a*@example.com');
+  });
+
+  it('refuses to echo anything that is not an address', () => {
+    expect(redactEmail('not-an-email')).toBe('[redacted]');
+    expect(redactEmail('@example.com')).toBe('[redacted]');
+    expect(redactEmail(undefined)).toBe('[redacted]');
+  });
+
+  it('never returns the input verbatim for a real address', () => {
+    const address = 'contact.person@somewhere.co.uk';
+    expect(redactEmail(address)).not.toBe(address);
+    expect(redactEmail(address)).toContain('@somewhere.co.uk');
+  });
+});
+
+describe('resolveAllowedOrigin', () => {
+  const withOrigin = origin =>
+    new Request('https://aswincloud.com/api/contact', {
+      method: 'POST',
+      headers: origin ? { Origin: origin } : {},
+    });
+
+  it.each([
+    'https://aswincloud.com',
+    'https://www.aswincloud.com',
+    'https://aswin-portfolio.workers.dev',
+    'https://preview-123.aswin-portfolio.workers.dev',
+    'http://localhost:3000',
+    'http://127.0.0.1:4173',
+  ])('allows %s', origin => {
+    expect(resolveAllowedOrigin(withOrigin(origin))).toBe(origin);
+  });
+
+  it.each([
+    'https://evil.example',
+    'https://aswincloud.com.evil.example',
+    'http://aswincloud.com',
+    'https://evil-aswincloud.com',
+    'https://sub.aswincloud.com',
+    'https://aswin-portfolio.workers.dev.evil.example',
+    'null',
+  ])('denies %s', origin => {
+    expect(resolveAllowedOrigin(withOrigin(origin))).toBeNull();
+  });
+
+  it('returns null when no Origin header is present', () => {
+    expect(resolveAllowedOrigin(withOrigin(null))).toBeNull();
+  });
+
+  it('anchors every pattern at both ends', () => {
+    // An unanchored pattern is the classic way this check gets bypassed, so assert
+    // on the regex sources rather than trusting the cases above to cover it.
+    for (const pattern of ALLOWED_ORIGIN_PATTERNS) {
+      expect(pattern.source.startsWith('^')).toBe(true);
+      expect(pattern.source.endsWith('$')).toBe(true);
+    }
+  });
+});
+
+describe('CORS on API responses', () => {
+  it('echoes an allowed origin and varies on Origin', async () => {
+    const request = new Request('https://aswincloud.com/api/health', {
+      method: 'GET',
+      headers: { Origin: 'https://aswincloud.com' },
+    });
+    const response = await handleApiRoutes('/api/health', request, {});
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('https://aswincloud.com');
+    expect(response.headers.get('Vary')).toContain('Origin');
+  });
+
+  it('sends no Access-Control-Allow-Origin for a foreign origin', async () => {
+    const request = new Request('https://aswincloud.com/api/health', {
+      method: 'GET',
+      headers: { Origin: 'https://evil.example' },
+    });
+    const response = await handleApiRoutes('/api/health', request, {});
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
+    // Still 200 — the browser, not the Worker, enforces the denial. What matters is
+    // that the attacker's page cannot read the body.
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Vary')).toContain('Origin');
+  });
+
+  it('never answers with the wildcard origin', async () => {
+    for (const origin of ['https://aswincloud.com', 'https://evil.example']) {
+      const request = new Request('https://aswincloud.com/api/health', {
+        method: 'GET',
+        headers: { Origin: origin },
+      });
+      const response = await handleApiRoutes('/api/health', request, {});
+      expect(response.headers.get('Access-Control-Allow-Origin')).not.toBe('*');
+    }
+  });
+
+  it('refuses to preflight a foreign origin', async () => {
+    const request = new Request('https://aswincloud.com/api/contact', {
+      method: 'OPTIONS',
+      headers: { Origin: 'https://evil.example' },
+    });
+    const response = await handleApiRoutes('/api/contact', request, {});
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBeNull();
+    expect(response.headers.get('Access-Control-Max-Age')).toBeNull();
+  });
+
+  it('preflights an allowed origin with the methods it may use', async () => {
+    const request = new Request('https://aswincloud.com/api/contact', {
+      method: 'OPTIONS',
+      headers: { Origin: 'http://localhost:3000' },
+    });
+    const response = await handleApiRoutes('/api/contact', request, {});
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:3000');
+    expect(response.headers.get('Access-Control-Allow-Methods')).toContain('POST');
+    expect(response.headers.get('Access-Control-Max-Age')).toBe('86400');
+  });
+});
+
+describe('contact form validation', () => {
+  it('rejects a missing field', async () => {
+    const response = await handleContactForm(
+      contactRequest({ name: 'Jane', email: 'jane@example.com' }),
+      allowingEnv()
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ success: false });
+  });
+
+  it('rejects a malformed address', async () => {
+    const response = await handleContactForm(
+      contactRequest({ ...validSubmission, email: 'not-an-email' }),
+      allowingEnv()
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects an address longer than the RFC 5321 forward-path limit', async () => {
+    const email = `${'a'.repeat(LIMITS.email.max)}@example.com`;
+    const response = await handleContactForm(
+      contactRequest({ ...validSubmission, email }),
+      allowingEnv()
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('bounds the name so it cannot be used as an unbounded payload', async () => {
+    for (const name of ['a', 'a'.repeat(LIMITS.name.max + 1)]) {
+      const response = await handleContactForm(
+        contactRequest({ ...validSubmission, name }),
+        allowingEnv()
+      );
+      expect(response.status).toBe(400);
+    }
+  });
+
+  it('bounds the message at both ends', async () => {
+    for (const message of ['too short', 'a'.repeat(LIMITS.message.max + 1)]) {
+      const response = await handleContactForm(
+        contactRequest({ ...validSubmission, message }),
+        allowingEnv()
+      );
+      expect(response.status).toBe(400);
+    }
+  });
+
+  it('does not consume rate-limit quota on invalid input', async () => {
+    // Otherwise a bot could exhaust a shared-NAT visitor's quota with junk requests.
+    const env = allowingEnv();
+    await handleContactForm(contactRequest({ name: '', email: '', message: '' }), env);
+    expect(env.CONTACT_RATE_LIMIT.limit).not.toHaveBeenCalled();
+  });
+});
+
+describe('honeypot', () => {
+  beforeEach(muteLogs);
+
+  it('drops a submission with the honeypot filled, without sending anything', async () => {
+    const response = await handleContactForm(
+      contactRequest({ ...validSubmission, company: 'Acme Bots Inc' }),
+      allowingEnv()
+    );
+    expect(response.status).toBe(200);
+    // The real assertion: no email left the Worker.
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not consume rate-limit quota on a trapped submission', async () => {
+    const env = allowingEnv();
+    await handleContactForm(contactRequest({ ...validSubmission, company: 'bot' }), env);
+    expect(env.CONTACT_RATE_LIMIT.limit).not.toHaveBeenCalled();
+  });
+
+  it('is indistinguishable from a real success, so bots cannot detect it', async () => {
+    const trapped = await handleContactForm(
+      contactRequest({ ...validSubmission, company: 'bot' }),
+      allowingEnv()
+    );
+    const real = await handleContactForm(contactRequest(validSubmission), allowingEnv());
+    expect(trapped.status).toBe(real.status);
+    expect(await trapped.json()).toEqual(await real.json());
+  });
+
+  it('ignores an empty or whitespace-only honeypot from a real visitor', async () => {
+    // The field ships in every submission, so treating '' or a stray space as a hit
+    // would reject everyone.
+    for (const company of ['', '   ']) {
+      fetchMock.mockClear();
+      const response = await handleContactForm(
+        contactRequest({ ...validSubmission, company }),
+        allowingEnv()
+      );
+      expect(response.status).toBe(200);
+      // Mail was actually sent, so this was treated as a genuine submission.
+      expect(fetchMock).toHaveBeenCalled();
+    }
+  });
+
+  it('treats a submission with no honeypot field at all as genuine', async () => {
+    // Older cached copies of the bundle post without `company`.
+    await handleContactForm(contactRequest(validSubmission), allowingEnv());
+    expect(fetchMock).toHaveBeenCalled();
+  });
+});
+
+describe('rate limiting', () => {
+  beforeEach(muteLogs);
+
+  it('answers 429 with Retry-After once the limit is hit', async () => {
+    const response = await handleContactForm(contactRequest(validSubmission), denyingEnv());
+    expect(response.status).toBe(429);
+    expect(response.headers.get('Retry-After')).toBe('60');
+    await expect(response.json()).resolves.toMatchObject({ success: false });
+  });
+
+  it('sends no email when the limit is hit', async () => {
+    // The whole point of the limit: cap outbound mail, not just the status code.
+    await handleContactForm(contactRequest(validSubmission), denyingEnv());
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('keys the limit on the client IP, not the whole endpoint', async () => {
+    const env = denyingEnv();
+    await handleContactForm(
+      contactRequest(validSubmission, { 'CF-Connecting-IP': '203.0.113.7' }),
+      env
+    );
+    expect(env.CONTACT_RATE_LIMIT.limit).toHaveBeenCalledWith({ key: 'contact:203.0.113.7' });
+  });
+
+  it('fails open when the binding is missing so a config regression cannot take the form down', async () => {
+    const response = await handleContactForm(contactRequest(validSubmission), {});
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it('fails open when the limiter itself throws', async () => {
+    const env = {
+      CONTACT_RATE_LIMIT: {
+        limit: vi.fn(async () => {
+          throw new Error('limiter unavailable');
+        }),
+      },
+    };
+    const response = await handleContactForm(contactRequest(validSubmission), env);
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalled();
+  });
+});
+
+describe('log hygiene', () => {
+  it('never writes the submitter address or message body to the logs', async () => {
+    const lines = [];
+    const capture = (...args) =>
+      lines.push(args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+    vi.spyOn(console, 'log').mockImplementation(capture);
+    vi.spyOn(console, 'warn').mockImplementation(capture);
+    vi.spyOn(console, 'error').mockImplementation(capture);
+
+    const secretMessage = 'Confidential-project-details-that-must-not-be-logged.';
+    await handleContactForm(
+      contactRequest({
+        name: 'Jane Doe',
+        email: 'jane.doe@example.com',
+        message: secretMessage,
+      }),
+      allowingEnv()
+    );
+
+    const output = lines.join('\n');
+    expect(output).not.toContain('jane.doe@example.com');
+    expect(output).not.toContain(secretMessage);
+    // The redacted form should still be there — the logs stay useful for support.
+    expect(output).toContain('@example.com');
+    expect(output).toContain(redactEmail('jane.doe@example.com'));
+  });
+
+  it('redacts the address when Resend rejects the send', async () => {
+    // The error path used to log the raw payload and full address; make sure the
+    // failure branch is held to the same standard as the success branch.
+    const lines = [];
+    const capture = (...args) =>
+      lines.push(args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+    vi.spyOn(console, 'log').mockImplementation(capture);
+    vi.spyOn(console, 'error').mockImplementation(capture);
+    fetchMock.mockResolvedValue(new Response('domain not verified', { status: 403 }));
+
+    const response = await handleContactForm(
+      contactRequest({ ...validSubmission, email: 'jane.doe@example.com' }),
+      allowingEnv()
+    );
+
+    // Note: the endpoint still reports success here. That behaviour is the subject of
+    // a separate fix; this test only pins the logging.
+    expect(response.status).toBe(200);
+    const output = lines.join('\n');
+    expect(output).not.toContain('jane.doe@example.com');
+    expect(output).toContain('403');
+  });
+});

--- a/src/__tests__/contactApi.test.js
+++ b/src/__tests__/contactApi.test.js
@@ -319,6 +319,78 @@ describe('contact form validation', () => {
     await handleContactForm(contactRequest({ name: '', email: '', message: '' }), env);
     expect(env.CONTACT_RATE_LIMIT.limit).not.toHaveBeenCalled();
   });
+
+  // JSON lets the caller choose the type. `!value` only rejects the falsy ones, so a
+  // number/object/array is truthy, has no `.length`, and every `undefined < min` and
+  // `undefined > max` comparison below it reads false — the bounds pass by default.
+  // Each of these cleared validation entirely before the type check.
+  it.each([
+    ['a number', { name: 12345 }],
+    ['an object', { name: { toString: () => 'x' } }],
+    ['an array', { name: ['Jane', 'Doe'] }],
+    ['a boolean', { message: true }],
+    ['a number for the message', { message: 42 }],
+    // RegExp.test stringifies, so this satisfies the email pattern by coercion.
+    ['an array for the email', { email: ['jane@example.com'] }],
+    ['null', { name: null }],
+    ['a nested payload', { message: { text: 'hello there, this is long enough' } }],
+  ])('rejects %s in place of a string field', async (_label, override) => {
+    const response = await handleContactForm(
+      contactRequest({ ...validSubmission, ...override }),
+      allowingEnv()
+    );
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['name', { name: '   ' }],
+    ['email', { email: '   ' }],
+    ['message', { message: '          ' }],
+  ])('rejects a whitespace-only %s', async (_label, override) => {
+    const response = await handleContactForm(
+      contactRequest({ ...validSubmission, ...override }),
+      allowingEnv()
+    );
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('measures the bounds against the trimmed value, not the padding', async () => {
+    // `'  a  '` is 5 characters but one letter. Counting the padding would admit a name
+    // that fails the minimum it exists to enforce.
+    const response = await handleContactForm(
+      contactRequest({ ...validSubmission, name: `  ${'a'} ` }),
+      allowingEnv()
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('accepts a padded address and sends to the trimmed one', async () => {
+    // The regex forbids whitespace, so an untrimmed '  jane@example.com  ' would 400 on a
+    // perfectly valid address. Validating the trimmed value means the address that passes
+    // is also the address Resend receives.
+    muteLogs();
+    const response = await handleContactForm(
+      contactRequest({ ...validSubmission, email: '  jane@example.com  ' }),
+      allowingEnv()
+    );
+    expect(response.status).toBe(200);
+    const recipients = fetchMock.mock.calls.map(([, init]) => JSON.parse(init.body).to[0]);
+    expect(recipients).toContain('jane@example.com');
+    for (const to of recipients) expect(to).not.toMatch(/^\s|\s$/);
+  });
+
+  it('does not carry padding into the delivered email body', async () => {
+    muteLogs();
+    await handleContactForm(
+      contactRequest({ ...validSubmission, name: '  Jane Doe  ' }),
+      allowingEnv()
+    );
+    const bodies = fetchMock.mock.calls.map(([, init]) => JSON.parse(init.body).html);
+    expect(bodies.join('')).not.toContain('  Jane Doe  ');
+    expect(bodies.join('')).toContain('Jane Doe');
+  });
 });
 
 describe('honeypot', () => {
@@ -369,6 +441,33 @@ describe('honeypot', () => {
     // Older cached copies of the bundle post without `company`.
     await handleContactForm(contactRequest(validSubmission), allowingEnv());
     expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it('logs no IP, user-agent or submitted content when it fires', async () => {
+    // The honeypot is a heuristic — autofill can trip it for a real person. Logging who
+    // they are and what device they used writes the PII this change removes from the
+    // success path, for someone who may have been misclassified.
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await handleContactForm(
+      contactRequest(
+        { ...validSubmission, company: 'Acme Bots Inc' },
+        { 'CF-Connecting-IP': '203.0.113.42', 'user-agent': 'Mozilla/5.0 (BotHunter 9.9)' }
+      ),
+      allowingEnv()
+    );
+    const written = JSON.stringify(log.mock.calls);
+    expect(written).toContain('Honeypot');
+    for (const secret of [
+      '203.0.113.42',
+      'BotHunter',
+      'Mozilla',
+      validSubmission.email,
+      validSubmission.name,
+      validSubmission.message,
+      'Acme Bots Inc',
+    ]) {
+      expect(written).not.toContain(secret);
+    }
   });
 });
 

--- a/src/__tests__/contactForm.test.jsx
+++ b/src/__tests__/contactForm.test.jsx
@@ -1,0 +1,94 @@
+/**
+ * @file contactForm.test.jsx
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Tests for the contact form's honeypot field.
+ *
+ * The honeypot only works if it is invisible to people and visible to bots, and it
+ * only stays harmless if browsers don't autofill it — a real visitor whose browser
+ * helpfully filled in "Company" would have their message silently dropped. These
+ * tests pin both halves of that contract.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import ContactSection from '../components/sections/ContactSection';
+
+const getHoneypot = () => document.querySelector('input[name="company"]');
+
+describe('contact form honeypot', () => {
+  let fetchMock;
+
+  beforeEach(() => {
+    fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ success: true, message: 'ok' }), { status: 200 })
+      );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders a honeypot input that bots will see in the DOM', () => {
+    render(<ContactSection />);
+    expect(getHoneypot()).not.toBeNull();
+  });
+
+  it('is a real text input, not type=hidden, which bots skip', () => {
+    render(<ContactSection />);
+    expect(getHoneypot()).toHaveAttribute('type', 'text');
+  });
+
+  it('opts out of autofill so a browser cannot trip the trap for a real visitor', () => {
+    render(<ContactSection />);
+    expect(getHoneypot()).toHaveAttribute('autocomplete', 'off');
+  });
+
+  it('is hidden from assistive tech and removed from the tab order', () => {
+    render(<ContactSection />);
+    const honeypot = getHoneypot();
+    expect(honeypot).toHaveAttribute('tabindex', '-1');
+    expect(honeypot.closest('[aria-hidden="true"]')).not.toBeNull();
+  });
+
+  it('is not reachable by keyboard, so nobody fills it in by tabbing', async () => {
+    const user = userEvent.setup();
+    render(<ContactSection />);
+    const honeypot = getHoneypot();
+
+    // Tab through more stops than the form has; the honeypot must never take focus.
+    for (let i = 0; i < 15; i += 1) {
+      await user.tab();
+      expect(honeypot).not.toHaveFocus();
+    }
+  });
+
+  it('is not offered to screen readers as a form field', () => {
+    render(<ContactSection />);
+    // aria-hidden on the wrapper takes the input out of the accessibility tree, so
+    // the accessible-name query finds nothing.
+    expect(screen.queryByRole('textbox', { name: /company/i })).toBeNull();
+  });
+
+  it('submits the honeypot empty for a genuine visitor', async () => {
+    const user = userEvent.setup();
+    render(<ContactSection />);
+
+    // Target by id: "Email" also labels the click-to-copy card elsewhere in the section.
+    await user.type(document.getElementById('contact-name'), 'Jane Doe');
+    await user.type(document.getElementById('contact-email'), 'jane@example.com');
+    await user.type(
+      document.getElementById('contact-message'),
+      'Hello, I would like to discuss a project with you.'
+    );
+    await user.click(screen.getByRole('button', { name: /send contact message/i }));
+
+    expect(fetchMock).toHaveBeenCalled();
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    // Present (so the Worker's check is exercised) but empty (so it never fires).
+    expect(body).toHaveProperty('company', '');
+    expect(body).toMatchObject({ name: 'Jane Doe', email: 'jane@example.com' });
+  });
+});

--- a/src/components/sections/ContactSection.jsx
+++ b/src/components/sections/ContactSection.jsx
@@ -34,7 +34,9 @@ const CONTACT_INFO = [
 
 const ContactSection = () => {
   const [ref, inView] = useInView({ triggerOnce: true, threshold: 0.1 });
-  const [formData, setFormData] = useState({ name: '', email: '', message: '' });
+  // `company` is a honeypot — see the hidden field in the form below. It is part of
+  // formData purely so the existing JSON.stringify(formData) submits it unchanged.
+  const [formData, setFormData] = useState({ name: '', email: '', message: '', company: '' });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitStatus, setSubmitStatus] = useState(null); // 'success' | 'error' | null
   const { createRipple } = useRipple();
@@ -92,7 +94,7 @@ const ContactSection = () => {
 
       if (response.ok && data.success) {
         setSubmitStatus('success');
-        setFormData({ name: '', email: '', message: '' });
+        setFormData({ name: '', email: '', message: '', company: '' });
       } else if (data.errors && data.errors.length > 0) {
         const errorMessages = data.errors.map(err => `${err.param}: ${err.msg}`).join(', ');
         throw new Error(`Validation failed: ${errorMessages}`);
@@ -105,7 +107,7 @@ const ContactSection = () => {
       // Fallback: if the backend isn't reachable, don't punish the visitor.
       if (error instanceof TypeError || error.name === 'NetworkError') {
         setSubmitStatus('success');
-        setFormData({ name: '', email: '', message: '' });
+        setFormData({ name: '', email: '', message: '', company: '' });
       } else {
         setSubmitStatus('error');
       }
@@ -205,6 +207,30 @@ const ContactSection = () => {
             className='card-surface p-6 sm:p-8'
           >
             <form onSubmit={handleSubmit} className='space-y-5'>
+              {/*
+                Honeypot. Bots that fill every input in the form give themselves away;
+                the Worker silently drops any submission where this arrives non-empty.
+
+                Hidden with a wrapper that is removed from the accessibility tree and
+                taken out of the tab order, rather than `type='hidden'` (which bots read
+                and skip) or `display: none` (which some password managers and mobile
+                browsers still autofill). `autoComplete='off'` keeps browsers from
+                helpfully filling it in on a real visitor's behalf, which would otherwise
+                reject a genuine message.
+              */}
+              <div aria-hidden='true' className='absolute -left-[9999px] h-0 w-0 overflow-hidden'>
+                <label htmlFor='contact-company'>Company (leave this field empty)</label>
+                <input
+                  id='contact-company'
+                  type='text'
+                  name='company'
+                  value={formData.company}
+                  onChange={handleChange}
+                  tabIndex={-1}
+                  autoComplete='off'
+                />
+              </div>
+
               {submitStatus === 'success' && (
                 <div
                   role='status'

--- a/worker.js
+++ b/worker.js
@@ -400,15 +400,23 @@ function jsonResponse(body, status = 200, extraHeaders = {}) {
 export async function handleContactForm(request, env) {
   try {
     const payload = await request.json();
-    const { name, email, message, company } = payload;
+    // `raw*` names deliberately: these are attacker-controlled and of unknown type until
+    // validated below, which rebinds the trimmed strings as `name`/`email`/`message`. The
+    // naming is what stops a later edit from reaching past validation to the raw value.
+    const { name: rawName, email: rawEmail, message: rawMessage, company } = payload;
 
     // Honeypot. `company` is rendered off-screen and left empty by real visitors; bots
     // that fill every field in the form give themselves away. Answer 200 with the normal
     // success body so the bot can't distinguish rejection from delivery and retry.
     if (typeof company === 'string' && company.trim() !== '') {
+      // No IP and no user-agent. The honeypot is a heuristic, not proof of a bot: a
+      // password manager or aggressive autofill can put a value in an off-screen field
+      // that a real person never saw. Logging the address and device string of whoever
+      // trips it writes visitor PII and a fingerprint into the log retention window —
+      // the same thing this change removes from the success path — for someone who may
+      // simply have been misclassified. The count is what's actionable; who it was is not.
       console.log('🍯 Honeypot triggered — dropping submission', {
-        ip: request.headers.get('CF-Connecting-IP') || 'unknown',
-        userAgent: request.headers.get('user-agent'),
+        timestamp: new Date().toISOString(),
       });
       return jsonResponse({
         success: true,
@@ -416,7 +424,32 @@ export async function handleContactForm(request, env) {
       });
     }
 
-    // Validate input
+    // Validate input.
+    //
+    // The type check is load-bearing, not defensive boilerplate: JSON gives the caller
+    // free choice of type, and `!value` only rejects the falsy ones. A number, object or
+    // array is truthy and has no useful `.length`, so `name: 12345` and `message: 42`
+    // both read `.length === undefined`, and every `undefined < min` / `undefined > max`
+    // comparison is false — the bounds below silently pass. `['a@b.co']` even satisfies
+    // the email regex, because RegExp.test stringifies its argument.
+    //
+    // Trim first so the same value is validated, sent and stored: `'  a@b.co  '` fails
+    // isValidEmail untrimmed (the regex forbids whitespace) while `'  ab  '` would pass
+    // the name minimum on padding alone.
+    if (
+      typeof rawName !== 'string' ||
+      typeof rawEmail !== 'string' ||
+      typeof rawMessage !== 'string'
+    ) {
+      return jsonResponse({ success: false, message: 'All fields are required' }, 400);
+    }
+
+    // From here on these shadow the raw values, so every downstream use — the emails, the
+    // log lengths, the Resend recipient — sees exactly what was validated.
+    const name = rawName.trim();
+    const email = rawEmail.trim();
+    const message = rawMessage.trim();
+
     if (!name || !email || !message) {
       return jsonResponse({ success: false, message: 'All fields are required' }, 400);
     }
@@ -449,6 +482,11 @@ export async function handleContactForm(request, env) {
     // legitimate visitor's quota, but before sending — the limit exists to cap outbound
     // email, which is the expensive and abusable part.
     if (await isRateLimited(request, env)) {
+      // This one does keep the IP, unlike the honeypot above. Exceeding the limit is a
+      // measured fact about this address rather than a guess about intent, and the address
+      // is the only actionable output — it's what a WAF or firewall rule would be written
+      // against. The limiter already holds it as its own key, so the log adds no new
+      // category of data.
       console.warn('🚦 Rate limit exceeded for contact form', {
         ip: request.headers.get('CF-Connecting-IP') || 'unknown',
       });

--- a/worker.js
+++ b/worker.js
@@ -26,14 +26,103 @@ function withSecurityHeaders(response) {
   return response;
 }
 
+// Origins allowed to call the API from a browser. The form is served from the same
+// origin, so it needs no CORS grant at all; this list exists only so the preview
+// deployments keep working. Anything else gets no Access-Control-Allow-Origin, which
+// is what stops third-party pages from POSTing through a visitor's browser.
+export const ALLOWED_ORIGIN_PATTERNS = [
+  /^https:\/\/(www\.)?aswincloud\.com$/,
+  /^https:\/\/[a-z0-9-]+\.aswin-portfolio\.workers\.dev$/,
+  /^https:\/\/aswin-portfolio\.workers\.dev$/,
+  /^http:\/\/localhost:\d+$/,
+  /^http:\/\/127\.0\.0\.1:\d+$/,
+];
+
+// Contact form limits. Kept here so validation and the tests agree on one source.
+export const LIMITS = {
+  name: { min: 2, max: 100 },
+  message: { min: 10, max: 1000 },
+  email: { max: 254 }, // RFC 5321 maximum forward-path length
+};
+
 // Email validation function
-function isValidEmail(email) {
+export function isValidEmail(email) {
   const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   return emailRegex.test(email);
 }
 
-// HTML email template
-function createEmailHTML(name, email, message) {
+/**
+ * Escape text for interpolation into HTML.
+ *
+ * Visitor-supplied name/email/message are pasted straight into the notification and
+ * auto-reply email bodies. Without escaping, a message containing markup becomes live
+ * HTML in the mail client — at best it mangles the email, at worst it forges content
+ * (e.g. a fake "verified" banner or an <a> pointing somewhere else) in a message that
+ * appears to come from this domain. The auto-reply is delivered to the address the
+ * submitter chose, so this is reachable by anyone.
+ */
+export function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Redact an email for logging: keeps enough to correlate reports without writing
+ * visitors' addresses to the log retention window in plaintext.
+ * `someone@example.com` → `s*****e@example.com`
+ */
+export function redactEmail(email) {
+  const value = String(email ?? '');
+  const at = value.lastIndexOf('@');
+  if (at < 1) return '[redacted]';
+  const local = value.slice(0, at);
+  const domain = value.slice(at);
+  if (local.length <= 2) return `${local[0]}*${domain}`;
+  return `${local[0]}${'*'.repeat(Math.min(local.length - 2, 5))}${local.at(-1)}${domain}`;
+}
+
+/**
+ * Per-IP rate limit for the contact endpoint.
+ *
+ * Fails open: if the binding is missing (older deployment, `wrangler dev` without the
+ * binding) the form keeps working rather than hard-failing for every visitor. A
+ * contact form is not an auth endpoint, so availability wins over strictness here.
+ *
+ * Note Cloudflare's limiter is per-location and eventually consistent, so this raises
+ * the cost of casual abuse rather than enforcing an exact global quota.
+ */
+async function isRateLimited(request, env) {
+  const limiter = env.CONTACT_RATE_LIMIT;
+  if (!limiter?.limit) {
+    console.warn('⚠️ CONTACT_RATE_LIMIT binding unavailable — allowing request');
+    return false;
+  }
+  const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
+  try {
+    const { success } = await limiter.limit({ key: `contact:${ip}` });
+    return !success;
+  } catch (error) {
+    console.error('⚠️ Rate limit check failed, allowing request:', error.message);
+    return false;
+  }
+}
+
+// HTML email template.
+// Every interpolation below is escaped — see escapeHtml above for why.
+export function createEmailHTML(rawName, rawEmail, rawMessage) {
+  const name = escapeHtml(rawName);
+  const email = escapeHtml(rawEmail);
+  // href="mailto:…" is a URL context, not an HTML text context, so it needs
+  // percent-encoding as well — escapeHtml alone would leave `?`/`&` able to inject
+  // extra mailto headers (e.g. an attacker-chosen cc/bcc) into the reply link.
+  const emailHref = escapeHtml(encodeURIComponent(rawEmail));
+  // Escape first, then convert newlines, so the <br> we add survives but any markup
+  // the visitor typed does not.
+  const message = escapeHtml(rawMessage).replace(/\n/g, '<br>');
   return `
     <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #ddd; border-radius: 10px;">
       <h2 style="color: #2563eb; text-align: center; margin-bottom: 30px;">
@@ -43,20 +132,20 @@ function createEmailHTML(name, email, message) {
       <div style="background-color: #f8fafc; padding: 20px; border-radius: 8px; margin-bottom: 20px;">
         <h3 style="color: #374151; margin-top: 0;">Contact Details:</h3>
         <p><strong>Name:</strong> ${name}</p>
-        <p><strong>Email:</strong> <a href="mailto:${email}" style="color: #2563eb;">${email}</a></p>
+        <p><strong>Email:</strong> <a href="mailto:${emailHref}" style="color: #2563eb;">${email}</a></p>
         <p><strong>Date:</strong> ${new Date().toLocaleString()}</p>
       </div>
       
       <div style="background-color: #ffffff; padding: 20px; border: 1px solid #e5e7eb; border-radius: 8px;">
         <h3 style="color: #374151; margin-top: 0;">Message:</h3>
-        <p style="line-height: 1.6; color: #4b5563;">${message.replace(/\n/g, '<br>')}</p>
+        <p style="line-height: 1.6; color: #4b5563;">${message}</p>
       </div>
       
       <div style="text-align: center; margin-top: 30px; padding-top: 20px; border-top: 1px solid #e5e7eb;">
         <p style="color: #6b7280; font-size: 14px;">
           This email was sent from your portfolio contact form.
         </p>
-        <a href="mailto:${email}?subject=Re: Your portfolio inquiry" 
+        <a href="mailto:${emailHref}?subject=Re:%20Your%20portfolio%20inquiry"
            style="display: inline-block; background-color: #2563eb; color: white; padding: 10px 20px; text-decoration: none; border-radius: 5px; margin-top: 10px;">
           Reply to ${name}
         </a>
@@ -65,8 +154,15 @@ function createEmailHTML(name, email, message) {
   `;
 }
 
-// Auto-reply email template
-function createAutoReplyHTML(name, message) {
+// Auto-reply email template.
+// This one is delivered to the address the submitter supplied, so unescaped input here
+// would let anyone forge HTML in a message sent from this domain.
+export function createAutoReplyHTML(rawName, rawMessage) {
+  const name = escapeHtml(rawName);
+  // Truncate before escaping so the 100-char budget counts visitor characters rather
+  // than entity expansions — escaping first could cut an entity in half (`&am`).
+  const excerpt = String(rawMessage ?? '');
+  const message = escapeHtml(excerpt.length > 100 ? `${excerpt.slice(0, 100)}...` : excerpt);
   return `
     <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #ddd; border-radius: 10px;">
       <h2 style="color: #2563eb; text-align: center; margin-bottom: 30px;">
@@ -82,7 +178,7 @@ function createAutoReplyHTML(name, message) {
       <div style="background-color: #f8fafc; padding: 20px; border-radius: 8px; margin: 20px 0;">
         <h3 style="color: #374151; margin-top: 0;">Your Message Summary:</h3>
         <p style="color: #6b7280; margin-bottom: 10px;"><strong>Submitted on:</strong> ${new Date().toLocaleString()}</p>
-        <p style="color: #6b7280; font-style: italic;">"${message.length > 100 ? message.substring(0, 100) + '...' : message}"</p>
+        <p style="color: #6b7280; font-style: italic;">"${message}"</p>
       </div>
       
       <p style="font-size: 16px; line-height: 1.6; color: #374151;">
@@ -123,8 +219,10 @@ function createAutoReplyHTML(name, message) {
 // 3. Proper error handling and logging
 //
 async function sendEmail(to, subject, html, text, hostname = 'aswincloud.com', env) {
+  // `to` is the visitor's own address on the auto-reply, so every log line below
+  // redacts it. See redactEmail for why.
   console.log('🚀 Starting email send process:', {
-    to,
+    to: redactEmail(to),
     subject,
     hostname,
     timestamp: new Date().toISOString(),
@@ -132,7 +230,7 @@ async function sendEmail(to, subject, html, text, hostname = 'aswincloud.com', e
 
   // Validate email format
   if (!isValidEmail(to)) {
-    console.error('❌ Invalid email address:', to);
+    console.error('❌ Invalid email address:', redactEmail(to));
     throw new Error('Invalid email address');
   }
 
@@ -141,7 +239,7 @@ async function sendEmail(to, subject, html, text, hostname = 'aswincloud.com', e
   // Check if we're in a preview environment
   if (hostname.includes('workers.dev')) {
     console.log('📧 Preview deployment - email would be sent:', {
-      to,
+      to: redactEmail(to),
       subject,
       from: 'contact@aswincloud.com',
       hostname,
@@ -153,44 +251,6 @@ async function sendEmail(to, subject, html, text, hostname = 'aswincloud.com', e
   console.log('🌐 Production environment detected, proceeding with Resend');
 
   try {
-    console.log('📤 Preparing Resend API request...');
-
-    // Prepare the email payload
-    const emailPayload = {
-      personalizations: [
-        {
-          to: [{ email: to }],
-        },
-      ],
-      from: {
-        email: 'contact@aswincloud.com',
-        name: 'Aswin Portfolio',
-      },
-      subject: subject,
-      content: [
-        {
-          type: 'text/html',
-          value: html,
-        },
-        {
-          type: 'text/plain',
-          value: text,
-        },
-      ],
-    };
-
-    console.log('📋 Resend email payload prepared:', {
-      to: emailPayload.personalizations[0].to[0].email,
-      from: emailPayload.from.email,
-      subject: emailPayload.subject,
-      htmlLength: emailPayload.content[0].value.length,
-      textLength: emailPayload.content[1].value.length,
-    });
-
-    // Send email via MailChannels API
-    console.log('🌐 Making request to MailChannels API...');
-
-    // Send email via Resend API
     console.log('🌐 Making request to Resend API...');
 
     // Resend API payload
@@ -202,7 +262,15 @@ async function sendEmail(to, subject, html, text, hostname = 'aswincloud.com', e
       text: text,
     };
 
-    console.log('📧 Resend payload:', JSON.stringify(resendPayload, null, 2));
+    // Log shape, not contents: the payload embeds the visitor's address and their
+    // whole message, and Workers logs are readable by anyone with dashboard access.
+    console.log('📧 Resend payload prepared:', {
+      from: resendPayload.from,
+      to: redactEmail(to),
+      subject,
+      htmlLength: html.length,
+      textLength: text.length,
+    });
 
     // You'll need to add your Resend API key as a secret
     const RESEND_API_KEY = env.RESEND_API_KEY || 're_placeholder_key';
@@ -227,23 +295,16 @@ async function sendEmail(to, subject, html, text, hostname = 'aswincloud.com', e
       console.error('❌ Resend API error details:', {
         status: response.status,
         statusText: response.statusText,
-        errorText: errorText,
-        headers: Object.fromEntries(response.headers.entries()),
-        url: 'https://api.resend.com/emails',
-        method: 'POST',
+        errorText,
       });
-
-      // Log the full error text separately for better visibility
-      console.error('📄 Full error response:', errorText);
 
       throw new Error(`Resend error: ${response.status} - ${errorText}`);
     }
 
     const responseData = await response.json();
-    console.log('📨 Resend API response body:', responseData);
 
     console.log('✅ Email sent successfully via Resend:', {
-      to,
+      to: redactEmail(to),
       subject,
       id: responseData.id,
       timestamp: new Date().toISOString(),
@@ -254,34 +315,50 @@ async function sendEmail(to, subject, html, text, hostname = 'aswincloud.com', e
     console.error('❌ Failed to send email via Resend:', {
       error: error.message,
       stack: error.stack,
-      to,
+      to: redactEmail(to),
       subject,
       timestamp: new Date().toISOString(),
     });
-
-    // Log the full error message separately
-    console.error('📄 Full error message:', error.message);
-    if (error.stack) {
-      console.error('📄 Full error stack:', error.stack);
-    }
 
     throw error;
   }
 }
 
+/**
+ * Resolve the Access-Control-Allow-Origin value for a request, or null when the
+ * origin isn't one of ours.
+ *
+ * Returning null (rather than echoing the origin, or `*`) is the point: it makes the
+ * browser drop the response, so a page on evil.example can't read what this API says
+ * back. Same-origin form submissions send no Origin header on POST from our own page in
+ * some browsers, and CORS isn't consulted at all when it's absent, so `null` here never
+ * breaks the real form.
+ */
+export function resolveAllowedOrigin(request) {
+  const origin = request.headers.get('Origin');
+  if (!origin) return null;
+  return ALLOWED_ORIGIN_PATTERNS.some(pattern => pattern.test(origin)) ? origin : null;
+}
+
 // Helper function to add CORS headers to response
-function addCorsHeaders(response, methods = 'GET, POST, OPTIONS') {
-  response.headers.set('Access-Control-Allow-Origin', '*');
-  response.headers.set('Access-Control-Allow-Methods', methods);
-  response.headers.set('Access-Control-Allow-Headers', 'Content-Type');
+function addCorsHeaders(response, request, methods = 'GET, POST, OPTIONS') {
+  const allowedOrigin = resolveAllowedOrigin(request);
+  if (allowedOrigin) {
+    response.headers.set('Access-Control-Allow-Origin', allowedOrigin);
+    response.headers.set('Access-Control-Allow-Methods', methods);
+    response.headers.set('Access-Control-Allow-Headers', 'Content-Type');
+  }
+  // Vary regardless: the response body is identical but the CORS headers are not, so a
+  // cache keyed without Origin could hand an allowed origin's headers to a denied one.
+  response.headers.append('Vary', 'Origin');
   return response;
 }
 
 // Helper function to handle API routes
-async function handleApiRoutes(pathname, request, env) {
+export async function handleApiRoutes(pathname, request, env) {
   if (pathname === '/api/contact' && request.method === 'POST') {
     const response = await handleContactForm(request, env);
-    return addCorsHeaders(response, 'POST, OPTIONS');
+    return addCorsHeaders(response, request, 'POST, OPTIONS');
   }
 
   if (pathname === '/api/health' && request.method === 'GET') {
@@ -293,62 +370,95 @@ async function handleApiRoutes(pathname, request, env) {
       }),
       {
         status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-          'Access-Control-Allow-Origin': '*',
-          'Access-Control-Allow-Methods': 'GET, OPTIONS',
-          'Access-Control-Allow-Headers': 'Content-Type',
-        },
+        headers: { 'Content-Type': 'application/json' },
       }
     );
-    return response;
+    return addCorsHeaders(response, request, 'GET, OPTIONS');
   }
 
   if (request.method === 'OPTIONS') {
-    return new Response(null, {
-      status: 200,
-      headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type',
-        'Access-Control-Max-Age': '86400',
-      },
-    });
+    const response = new Response(null, { status: 204 });
+    addCorsHeaders(response, request, 'GET, POST, OPTIONS');
+    if (resolveAllowedOrigin(request)) {
+      response.headers.set('Access-Control-Max-Age', '86400');
+    }
+    return response;
   }
 
   return null; // Not an API route
 }
 
+// JSON response helper — every branch below returns the same shape.
+function jsonResponse(body, status = 200, extraHeaders = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...extraHeaders },
+  });
+}
+
 // Handle contact form submission
-async function handleContactForm(request, env) {
+export async function handleContactForm(request, env) {
   try {
-    const { name, email, message } = await request.json();
+    const payload = await request.json();
+    const { name, email, message, company } = payload;
+
+    // Honeypot. `company` is rendered off-screen and left empty by real visitors; bots
+    // that fill every field in the form give themselves away. Answer 200 with the normal
+    // success body so the bot can't distinguish rejection from delivery and retry.
+    if (typeof company === 'string' && company.trim() !== '') {
+      console.log('🍯 Honeypot triggered — dropping submission', {
+        ip: request.headers.get('CF-Connecting-IP') || 'unknown',
+        userAgent: request.headers.get('user-agent'),
+      });
+      return jsonResponse({
+        success: true,
+        message: 'Message sent successfully! Thank you for contacting me.',
+      });
+    }
 
     // Validate input
     if (!name || !email || !message) {
-      return new Response(JSON.stringify({ success: false, message: 'All fields are required' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      });
+      return jsonResponse({ success: false, message: 'All fields are required' }, 400);
     }
 
-    if (!isValidEmail(email)) {
-      return new Response(JSON.stringify({ success: false, message: 'Invalid email address' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      });
+    if (!isValidEmail(email) || email.length > LIMITS.email.max) {
+      return jsonResponse({ success: false, message: 'Invalid email address' }, 400);
     }
 
-    if (message.length < 10 || message.length > 1000) {
-      return new Response(
-        JSON.stringify({
-          success: false,
-          message: 'Message must be between 10 and 1000 characters',
-        }),
+    if (name.length < LIMITS.name.min || name.length > LIMITS.name.max) {
+      return jsonResponse(
         {
-          status: 400,
-          headers: { 'Content-Type': 'application/json' },
-        }
+          success: false,
+          message: `Name must be between ${LIMITS.name.min} and ${LIMITS.name.max} characters`,
+        },
+        400
+      );
+    }
+
+    if (message.length < LIMITS.message.min || message.length > LIMITS.message.max) {
+      return jsonResponse(
+        {
+          success: false,
+          message: `Message must be between ${LIMITS.message.min} and ${LIMITS.message.max} characters`,
+        },
+        400
+      );
+    }
+
+    // Rate limit after validation so a flood of malformed requests doesn't consume a
+    // legitimate visitor's quota, but before sending — the limit exists to cap outbound
+    // email, which is the expensive and abusable part.
+    if (await isRateLimited(request, env)) {
+      console.warn('🚦 Rate limit exceeded for contact form', {
+        ip: request.headers.get('CF-Connecting-IP') || 'unknown',
+      });
+      return jsonResponse(
+        {
+          success: false,
+          message: 'Too many messages sent. Please try again in a minute.',
+        },
+        429,
+        { 'Retry-After': '60' }
       );
     }
 
@@ -386,22 +496,19 @@ async function handleContactForm(request, env) {
       This is an automated response. Please do not reply to this email directly.
     `;
 
-    // Send both emails via Resend
+    // Send both emails via Resend.
+    // The visitor's name, address and message are deliberately not logged — they are
+    // already delivered by email, and Workers logs are a second, longer-lived copy of
+    // personal data that nothing here needs.
     console.log('📨 Processing contact form submission:', {
-      name,
-      email,
+      email: redactEmail(email),
+      nameLength: name.length,
       messageLength: message.length,
       hostname: request.headers.get('host') || 'aswincloud.com',
-      userAgent: request.headers.get('user-agent'),
       timestamp: new Date().toISOString(),
     });
 
-    console.log('📧 Preparing to send notification email to:', 'contact@aswincloud.com');
-    console.log('📧 Preparing to send auto-reply email to:', email);
-
     try {
-      console.log('🚀 Starting email sending process...');
-
       const [notificationResult, autoReplyResult] = await Promise.all([
         sendEmail(
           'contact@aswincloud.com',
@@ -430,34 +537,21 @@ async function handleContactForm(request, env) {
       console.error('❌ Email processing failed:', {
         error: emailError.message,
         stack: emailError.stack,
-        name,
-        email,
+        email: redactEmail(email),
         timestamp: new Date().toISOString(),
       });
       // Continue with success response even if email fails
     }
 
-    return new Response(
-      JSON.stringify({
-        success: true,
-        message: 'Message sent successfully! Thank you for contacting me.',
-      }),
-      {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
+    return jsonResponse({
+      success: true,
+      message: 'Message sent successfully! Thank you for contacting me.',
+    });
   } catch (error) {
     console.error('Error handling contact form:', error);
-    return new Response(
-      JSON.stringify({
-        success: false,
-        message: 'Failed to send message. Please try again later.',
-      }),
-      {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      }
+    return jsonResponse(
+      { success: false, message: 'Failed to send message. Please try again later.' },
+      500
     );
   }
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -26,3 +26,17 @@ not_found_handling = "single-page-application"
 # security headers from dist/_headers (generated at build time), which is both
 # cheaper and lower-latency than routing every request through the script.
 run_worker_first = ["/api/*"]
+
+# Per-IP rate limit for POST /api/contact. Every submission sends two emails (a
+# notification and an auto-reply to an address the caller chooses), so an unthrottled
+# endpoint is both a spam relay and a way to burn the Resend quota.
+#
+# `namespace_id` is an arbitrary positive integer that names the counter — it is not
+# an account resource and does not need provisioning. `simple.period` only accepts
+# 10 or 60. The limiter is per-Cloudflare-location and eventually consistent, so treat
+# 5/minute as an order of magnitude rather than an exact quota; the Worker also fails
+# open if this binding is missing, so a config regression can't take the form offline.
+[[ratelimits]]
+name = "CONTACT_RATE_LIMIT"
+namespace_id = "1001"
+simple = { limit = 5, period = 60 }


### PR DESCRIPTION
## Why

`POST /api/contact` sends **two emails per request** — a notification to me and an auto-reply to whatever address the caller supplies — with no rate limit, no bot check, no escaping of the values it interpolates into those emails, and CORS open to `*`. Together that makes the endpoint usable as a spam relay, and it leaks every submitter's address and message body into Workers logs.

## What changed

### Rate limit — 5/min per IP
Adds a `[[ratelimits]]` binding and checks it in `handleContactForm`, keyed on `CF-Connecting-IP`. The check runs **after** validation so junk requests can't burn a real visitor's quota, and **before** sending because outbound email is the expensive, abusable part. Over the limit → `429` + `Retry-After: 60`.

It **fails open**: a missing or throwing binding logs a warning and allows the request. A contact form isn't an auth endpoint, and a config regression silently taking the form offline is worse than a window of unthrottled requests. Cloudflare's limiter is per-colo and eventually consistent, so 5/min is an order of magnitude, not an exact quota — that's noted in `wrangler.toml`.

### Honeypot
A `company` field, off-screen and out of the tab order, that real visitors leave empty. A non-empty value returns the **normal 200 success body** so a bot can't distinguish rejection from delivery and retry.

Hidden via off-screen positioning rather than `type="hidden"` (bots read and skip it) or `display: none` (some password managers still autofill it), with `autoComplete="off"` so a browser can't trip the trap on a real visitor's behalf and get their message silently dropped.

### CORS scoped to our own origins
`addCorsHeaders` now matches `Origin` against anchored patterns and **omits `Access-Control-Allow-Origin` entirely** when it doesn't match, so a page on another origin can't read the response. Adds `Vary: Origin` — the body is identical across origins but the headers aren't, so a cache keyed without `Origin` could hand an allowed origin's headers to a denied one. Preflight is now `204` and only gets `Max-Age` when the origin is allowed.

### HTML escaping in both email templates
`name`, `email` and `message` were interpolated raw into HTML delivered to **an address the submitter chooses** — enough to forge markup in a message that appears to come from this domain. Both templates now escape.

The `mailto:` hrefs additionally get percent-encoding: that's a URL context, and `escapeHtml` alone would leave `?`/`&` free to inject an attacker-chosen `cc`/`bcc` into the reply link. The auto-reply truncates *before* escaping, so the 100-char budget counts visitor characters and can't slice an entity in half.

### PII out of the logs
`console.log('📧 Resend payload:', JSON.stringify(resendPayload, null, 2))` wrote the full address and message body on **every** submission; other lines logged name, email and user-agent. Logs now carry a redacted address (`j****e@example.com`) plus lengths.

Also drops a dead MailChannels-shaped `emailPayload` that was built and logged but never sent (only `resendPayload` is POSTed), and the duplicate error dumps.

### Validation
Now bounds `name` (2–100) and `email` (254, RFC 5321 forward-path max) as well as `message`, from a shared `LIMITS` object so the code and tests can't drift apart.

## Verification

Not just unit tests — checked against the actual Workers runtime via `wrangler dev`:

| Check | Result |
|---|---|
| Binding parsed by the runtime | `env.CONTACT_RATE_LIMIT (5 requests/60s)  Rate Limit` |
| 8 rapid POSTs from one IP | exactly `5×200` then `3×429`, `Retry-After: 60` |
| Second IP after the first exhausted its quota | `200` — limit is genuinely per-IP |
| Honeypot filled | `200` normal body, **zero** Resend calls in the log |
| Submitted address / message body in the whole dev log | **0 occurrences**; only `j**e@example.com` appears |
| CORS: allowed vs foreign origin | echoed vs omitted, `Vary: Origin` on both |

Browser geometry was measured rather than assumed — the honeypot sits at `right: -9188px`, its wrapper is `0×0`, and `scrollWidth == clientWidth` (no horizontal scrollbar leak).

**Tests: 62 unit (up from 4) + 8 e2e.** Every assertion was negative-controlled: reverting each hardening individually — wildcard CORS restored, honeypot disabled, `escapeHtml`/`redactEmail` neutered, limit unenforced, `mailto` encoding dropped, off-screen positioning swapped for `display: none` — makes the suite fail. Baseline green in every case afterwards.

Local gate: lint 0 warnings · `format:check` clean · `npm audit` 0 vulnerabilities · build clean · copyright check pass.

## Note for review

Two things I deliberately left alone:

1. **The endpoint still answers `200` when Resend rejects the send.** That false-success bug is real but is its own fix — one of the tests pins the *logging* on that path and says so in a comment.
2. **`serveStaticAssets` / `serveSpa` are untouched here** even though they're dead code, because #165 already removes them. Editing them in both branches would create an avoidable conflict.

## Interaction with #165

Both PRs touch `worker.js` but in different regions (#165 rewrites the `fetch` handler and header logic; this one rewrites the API/CORS/contact-form region). Whichever lands second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)