### PR TITLE
fix(contact): stop reporting a failed submission as sent

### DIFF
--- a/e2e/contactFailure.spec.js
+++ b/e2e/contactFailure.spec.js
@@ -1,0 +1,116 @@
+/**
+ * @file e2e/contactFailure.spec.js
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @author Aswin
+ * @description Browser-level checks that a failed contact submission is reported as a
+ *   failure, not a success.
+ *
+ * The jsdom tests cover the same logic, but the failure this guards against is one a
+ * visitor experiences in a real browser: a genuinely aborted request (offline, DNS,
+ * CORS) previously produced "Message sent successfully" and a cleared form. Only a real
+ * engine actually rejects fetch() the way that path depends on, so it is worth asserting
+ * here too — and the mailto href has to survive real URL parsing.
+ */
+import { test, expect } from '@playwright/test';
+
+const NAME = 'Jane Doe';
+const EMAIL = 'jane@example.com';
+const MESSAGE = 'Hello, I would like to discuss a project with you.';
+
+test.beforeEach(async ({ page }) => {
+  await page.route(/googletagmanager\.com|google-analytics\.com|chatwoot|widget/i, r => r.abort());
+});
+
+/** Fill the form with valid values and submit. */
+const fillAndSubmit = async page => {
+  await page.goto('/#contact');
+  await page.locator('#contact-name').fill(NAME);
+  await page.locator('#contact-email').fill(EMAIL);
+  await page.locator('#contact-message').fill(MESSAGE);
+  await page.getByRole('button', { name: /send contact message/i }).click();
+};
+
+test.describe('contact form when delivery fails', () => {
+  test('an aborted request is reported as a failure, not a success', async ({ page }) => {
+    // A real abort: fetch() rejects with a TypeError in the page, which is exactly the
+    // case that used to display success.
+    await page.route('**/api/contact', route => route.abort('failed'));
+    await fillAndSubmit(page);
+
+    const alert = page.locator('[role="alert"]', { hasText: /wasn't sent|wasn’t sent/ });
+    await expect(alert).toBeVisible();
+    await expect(page.getByText(/message sent successfully/i)).toHaveCount(0);
+  });
+
+  test("the visitor's text is preserved so nothing has to be retyped", async ({ page }) => {
+    await page.route('**/api/contact', route => route.abort('failed'));
+    await fillAndSubmit(page);
+
+    await expect(page.locator('[role="alert"]')).toBeVisible();
+    await expect(page.locator('#contact-message')).toHaveValue(MESSAGE);
+    await expect(page.locator('#contact-name')).toHaveValue(NAME);
+    await expect(page.locator('#contact-email')).toHaveValue(EMAIL);
+  });
+
+  test('the mailto fallback is offered and carries the message', async ({ page }) => {
+    await page.route('**/api/contact', route => route.abort('failed'));
+    await fillAndSubmit(page);
+
+    const link = page.locator('a[href^="mailto:contact@aswincloud.com?"]');
+    await expect(link).toBeVisible();
+
+    // Parse it the way the browser will hand it to the mail client.
+    const href = await link.getAttribute('href');
+    const url = new URL(href);
+    expect(url.searchParams.get('body')).toBe(MESSAGE);
+    expect(url.searchParams.get('subject')).toContain(NAME);
+  });
+
+  test("a 502 from the Worker (email provider down) shows the fallback, not 'check your input'", async ({
+    page,
+  }) => {
+    await page.route('**/api/contact', route =>
+      route.fulfill({
+        status: 502,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: false, delivered: false, message: 'not delivered' }),
+      })
+    );
+    await fillAndSubmit(page);
+
+    await expect(page.locator('a[href^="mailto:contact@aswincloud.com?"]')).toBeVisible();
+    // The validation checklist would be misleading advice: nothing about the input is wrong.
+    await expect(page.getByText(/please check/i)).toHaveCount(0);
+  });
+
+  test('a 400 shows the validation checklist and no fallback', async ({ page }) => {
+    await page.route('**/api/contact', route =>
+      route.fulfill({
+        status: 400,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: false, message: 'Invalid email address' }),
+      })
+    );
+    await fillAndSubmit(page);
+
+    await expect(page.getByText(/please check/i)).toBeVisible();
+    await expect(page.locator('a[href^="mailto:contact@aswincloud.com?"]')).toHaveCount(0);
+    await expect(page.getByText(/message sent successfully/i)).toHaveCount(0);
+  });
+
+  test('a confirmed delivery still reports success and clears the form', async ({ page }) => {
+    // The counterpart to the above: the fix must not make success unreachable.
+    await page.route('**/api/contact', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true, delivered: true, message: 'ok' }),
+      })
+    );
+    await fillAndSubmit(page);
+
+    await expect(page.getByText(/message sent successfully/i)).toBeVisible();
+    await expect(page.locator('#contact-message')).toHaveValue('');
+    await expect(page.locator('a[href^="mailto:contact@aswincloud.com?"]')).toHaveCount(0);
+  });
+});

--- a/src/__tests__/contactApi.test.js
+++ b/src/__tests__/contactApi.test.js
@@ -33,9 +33,14 @@ import {
  */
 let fetchMock;
 beforeEach(() => {
+  // mockImplementation, not mockResolvedValue: a single Response instance shared across
+  // both sends would have its body consumed by the first, and the second read throws
+  // "Body has already been read". Each call gets its own.
   fetchMock = vi
     .spyOn(globalThis, 'fetch')
-    .mockResolvedValue(new Response(JSON.stringify({ id: 'stub-email-id' }), { status: 200 }));
+    .mockImplementation(
+      async () => new Response(JSON.stringify({ id: 'stub-email-id' }), { status: 200 })
+    );
 });
 afterEach(() => {
   vi.restoreAllMocks();
@@ -551,18 +556,93 @@ describe('log hygiene', () => {
       lines.push(args.map(a => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
     vi.spyOn(console, 'log').mockImplementation(capture);
     vi.spyOn(console, 'error').mockImplementation(capture);
-    fetchMock.mockResolvedValue(new Response('domain not verified', { status: 403 }));
+    // Fresh Response per call — see the note on the global stub.
+    fetchMock.mockImplementation(async () => new Response('domain not verified', { status: 403 }));
 
     const response = await handleContactForm(
       contactRequest({ ...validSubmission, email: 'jane.doe@example.com' }),
       allowingEnv()
     );
 
-    // Note: the endpoint still reports success here. That behaviour is the subject of
-    // a separate fix; this test only pins the logging.
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(502);
     const output = lines.join('\n');
     expect(output).not.toContain('jane.doe@example.com');
     expect(output).toContain('403');
+  });
+});
+
+describe('delivery outcome', () => {
+  beforeEach(muteLogs);
+
+  /**
+   * Both sends go to the same URL, so route by payload: `to` is contact@aswincloud.com
+   * for the notification and the visitor's address for the auto-reply.
+   */
+  const routeResend = ({ notification, autoReply }) => {
+    fetchMock.mockImplementation(async (_url, init) => {
+      const { to } = JSON.parse(init.body);
+      const outcome = to[0] === 'contact@aswincloud.com' ? notification : autoReply;
+      return outcome === 'ok'
+        ? new Response(JSON.stringify({ id: 'stub-email-id' }), { status: 200 })
+        : new Response('rejected by provider', { status: 422 });
+    });
+  };
+
+  it('reports success when both emails are sent', async () => {
+    routeResend({ notification: 'ok', autoReply: 'ok' });
+    const response = await handleContactForm(contactRequest(validSubmission), allowingEnv());
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ success: true, delivered: true });
+  });
+
+  // The bug this suite exists for: the message reached nobody, and the caller was told
+  // it had been sent.
+  it('reports failure when the notification email could not be sent', async () => {
+    routeResend({ notification: 'fail', autoReply: 'ok' });
+    const response = await handleContactForm(contactRequest(validSubmission), allowingEnv());
+
+    expect(response.status).toBe(502);
+    const body = await response.json();
+    expect(body).toMatchObject({ success: false, delivered: false });
+    // The client shows a mailto fallback, so the address has to be in the copy.
+    expect(body.message).toContain('contact@aswincloud.com');
+  });
+
+  it('still reports success when only the courtesy auto-reply fails', async () => {
+    // The submission did arrive. Telling the visitor it failed would be false and
+    // would prompt a duplicate.
+    routeResend({ notification: 'ok', autoReply: 'fail' });
+    const response = await handleContactForm(contactRequest(validSubmission), allowingEnv());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ success: true, delivered: true });
+  });
+
+  it('attempts the auto-reply even when the notification fails', async () => {
+    // allSettled, not all: a short-circuit here would drop a send that might succeed.
+    routeResend({ notification: 'fail', autoReply: 'ok' });
+    await handleContactForm(contactRequest(validSubmission), allowingEnv());
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports failure when the transport itself throws', async () => {
+    fetchMock.mockRejectedValue(new TypeError('network unreachable'));
+    const response = await handleContactForm(contactRequest(validSubmission), allowingEnv());
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toMatchObject({ success: false, delivered: false });
+  });
+
+  it('gives the honeypot a response byte-identical to a real success', async () => {
+    // Any difference in shape — including the new `delivered` field — would tell a bot
+    // it had been detected.
+    routeResend({ notification: 'ok', autoReply: 'ok' });
+    const real = await handleContactForm(contactRequest(validSubmission), allowingEnv());
+    const trapped = await handleContactForm(
+      contactRequest({ ...validSubmission, company: 'AcmeBot' }),
+      allowingEnv()
+    );
+
+    expect(trapped.status).toBe(real.status);
+    expect(await trapped.text()).toBe(await real.text());
   });
 });

--- a/src/__tests__/contactSubmit.test.jsx
+++ b/src/__tests__/contactSubmit.test.jsx
@@ -1,0 +1,208 @@
+/**
+ * @file contactSubmit.test.jsx
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Tests for what the contact form tells the visitor after submitting.
+ *
+ * The bug these exist to prevent: a failed send reported as "Message sent
+ * successfully" with the form cleared. The visitor then has no copy of what they
+ * wrote and no reason to follow up, and the message is simply lost. So the
+ * assertions here are mostly negative — after every failure path, the success
+ * text must be absent and the typed text must still be there.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import ContactSection from '../components/sections/ContactSection';
+
+const NAME = 'Jane Doe';
+const EMAIL = 'jane@example.com';
+const MESSAGE = 'Hello, I would like to discuss a project with you.';
+
+/** Target by id: "Email" also labels the click-to-copy card elsewhere in the section. */
+const fields = () => ({
+  name: document.getElementById('contact-name'),
+  email: document.getElementById('contact-email'),
+  message: document.getElementById('contact-message'),
+});
+
+const json = (body, status = 200) =>
+  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+
+describe('contact form submission outcomes', () => {
+  let fetchMock;
+
+  beforeEach(() => {
+    fetchMock = vi.spyOn(globalThis, 'fetch');
+    // The component logs failures; keep the test output readable.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /** Fill in valid values and submit. */
+  const submit = async () => {
+    const user = userEvent.setup();
+    render(<ContactSection />);
+    const f = fields();
+    await user.type(f.name, NAME);
+    await user.type(f.email, EMAIL);
+    await user.type(f.message, MESSAGE);
+    await user.click(screen.getByRole('button', { name: /send contact message/i }));
+    return user;
+  };
+
+  const successText = () => screen.queryByText(/message sent successfully/i);
+  const failureAlert = () => screen.queryByText(/wasn't sent|wasn’t sent/i);
+  const mailtoLink = () =>
+    document.querySelector('a[href^="mailto:contact@aswincloud.com?"]') ?? null;
+
+  describe('when the API confirms delivery', () => {
+    it('reports success and clears the form', async () => {
+      fetchMock.mockResolvedValue(json({ success: true, delivered: true, message: 'ok' }));
+      await submit();
+
+      await waitFor(() => expect(successText()).not.toBeNull());
+      expect(failureAlert()).toBeNull();
+      expect(fields().message).toHaveValue('');
+    });
+  });
+
+  // Each of these is a case where the previous implementation, or a plausible
+  // simplification of it, would have claimed success.
+  describe.each([
+    {
+      label: 'the network never completed (offline, DNS, CORS)',
+      // This is the exact case the old code treated as success.
+      arrange: mock => mock.mockRejectedValue(new TypeError('Failed to fetch')),
+    },
+    {
+      label: 'the Worker could not deliver the email (502)',
+      arrange: mock =>
+        mock.mockResolvedValue(json({ success: false, delivered: false, message: 'nope' }, 502)),
+    },
+    {
+      label: 'the Worker errored (500)',
+      arrange: mock => mock.mockResolvedValue(json({ success: false, message: 'boom' }, 500)),
+    },
+    {
+      label: 'the response was not JSON at all (proxy error page)',
+      arrange: mock =>
+        mock.mockResolvedValue(
+          new Response('<html>502 Bad Gateway</html>', {
+            status: 502,
+            headers: { 'Content-Type': 'text/html' },
+          })
+        ),
+    },
+    {
+      label: 'the response was 200 but success was false',
+      arrange: mock => mock.mockResolvedValue(json({ success: false, message: 'nope' }, 200)),
+    },
+  ])('when $label', ({ arrange }) => {
+    // Braces, not a concise body: returning the mock would hand Vitest a thenable
+    // that resolves to the configured rejection, failing the hook itself.
+    beforeEach(() => {
+      arrange(fetchMock);
+    });
+
+    it('does not claim the message was sent', async () => {
+      await submit();
+      await waitFor(() => expect(failureAlert()).not.toBeNull());
+      expect(successText()).toBeNull();
+    });
+
+    it('keeps what the visitor typed', async () => {
+      await submit();
+      await waitFor(() => expect(failureAlert()).not.toBeNull());
+      // Losing the text is what makes the false success actively harmful.
+      expect(fields().message).toHaveValue(MESSAGE);
+      expect(fields().name).toHaveValue(NAME);
+      expect(fields().email).toHaveValue(EMAIL);
+    });
+
+    it('offers the direct email address as a fallback', async () => {
+      await submit();
+      await waitFor(() => expect(failureAlert()).not.toBeNull());
+      expect(mailtoLink()).not.toBeNull();
+    });
+
+    it('announces the failure to assistive tech', async () => {
+      await submit();
+      await waitFor(() => expect(failureAlert()).not.toBeNull());
+      expect(failureAlert().closest('[role="alert"]')).not.toBeNull();
+    });
+
+    it('re-enables the submit button so a retry is possible', async () => {
+      await submit();
+      await waitFor(() => expect(failureAlert()).not.toBeNull());
+      expect(screen.getByRole('button', { name: /send contact message/i })).not.toBeDisabled();
+    });
+  });
+
+  describe('the mailto fallback', () => {
+    beforeEach(() => {
+      fetchMock.mockRejectedValue(new TypeError('Failed to fetch'));
+    });
+
+    it("carries the visitor's message across so nothing is retyped", async () => {
+      await submit();
+      await waitFor(() => expect(mailtoLink()).not.toBeNull());
+
+      const url = new URL(mailtoLink().getAttribute('href'));
+      expect(url.searchParams.get('body')).toBe(MESSAGE);
+      expect(url.searchParams.get('subject')).toContain(NAME);
+    });
+
+    it('encodes text that would otherwise break out of the mailto', async () => {
+      const user = userEvent.setup();
+      render(<ContactSection />);
+      const f = fields();
+      await user.type(f.name, NAME);
+      await user.type(f.email, EMAIL);
+      // `&` and `?` unencoded would terminate the body and be read as further
+      // mailto headers — i.e. the visitor's own text could inject a cc/bcc.
+      await user.type(f.message, 'A & B ? cc=someone@evil.test — does encoding hold up');
+      await user.click(screen.getByRole('button', { name: /send contact message/i }));
+
+      await waitFor(() => expect(mailtoLink()).not.toBeNull());
+      const href = mailtoLink().getAttribute('href');
+      const url = new URL(href);
+      expect(url.searchParams.get('body')).toBe(
+        'A & B ? cc=someone@evil.test — does encoding hold up'
+      );
+      // Exactly two params: the raw `&`/`?` did not create extra ones.
+      expect([...url.searchParams.keys()]).toEqual(['subject', 'body']);
+    });
+  });
+
+  describe('when the input itself was rejected', () => {
+    it('shows the validation checklist rather than the direct-email fallback', async () => {
+      // A 400 means editing the form can succeed, so pointing at a mailto would be
+      // the wrong advice.
+      fetchMock.mockResolvedValue(json({ success: false, message: 'Invalid email address' }, 400));
+      await submit();
+
+      await waitFor(() => expect(screen.queryByText(/please check/i)).not.toBeNull());
+      expect(successText()).toBeNull();
+      expect(failureAlert()).toBeNull();
+      expect(mailtoLink()).toBeNull();
+    });
+
+    it('does not call the API when a required field is empty', async () => {
+      const user = userEvent.setup();
+      render(<ContactSection />);
+      await user.type(fields().name, NAME);
+      await user.click(screen.getByRole('button', { name: /send contact message/i }));
+
+      // The inputs carry `required`, so the browser blocks the submit event before
+      // handleSubmit runs — hence no in-app message here. What matters either way is
+      // that nothing was sent and nothing claimed success.
+      expect(document.querySelector('form').checkValidity()).toBe(false);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(successText()).toBeNull();
+    });
+  });
+});

--- a/src/components/sections/ContactSection.jsx
+++ b/src/components/sections/ContactSection.jsx
@@ -2,9 +2,9 @@
  * @file ContactSection.jsx
  * @author Aswin
  * @copyright © 2025 Aswin. All rights reserved.
- * @description Contact — dark form + contact cards. Submit logic (POST
- *   /api/contact with graceful offline fallback) is unchanged from the
- *   original; only the presentation is reskinned.
+ * @description Contact — dark form + contact cards. Submits to POST /api/contact
+ *   and distinguishes three outcomes: sent, input rejected (fixable by editing),
+ *   and not delivered (offer the direct address, keep what was typed).
  */
 
 import React, { useState } from 'react';
@@ -32,13 +32,27 @@ const CONTACT_INFO = [
   },
 ];
 
+/**
+ * Distinguishes "the visitor can fix this by editing the form" from "the message did not
+ * get through". They need different copy: a validation checklist is useless advice when
+ * the API is down, and the direct address is noise when the email is simply malformed.
+ */
+class SubmitError extends Error {
+  constructor(kind) {
+    super(`Submit failed: ${kind}`);
+    this.name = 'SubmitError';
+    this.kind = kind; // 'invalid' | 'failed'
+  }
+}
+
 const ContactSection = () => {
   const [ref, inView] = useInView({ triggerOnce: true, threshold: 0.1 });
   // `company` is a honeypot — see the hidden field in the form below. It is part of
   // formData purely so the existing JSON.stringify(formData) submits it unchanged.
   const [formData, setFormData] = useState({ name: '', email: '', message: '', company: '' });
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [submitStatus, setSubmitStatus] = useState(null); // 'success' | 'error' | null
+  // null | 'success' | 'invalid' (visitor can fix it) | 'failed' (delivery failed)
+  const [submitStatus, setSubmitStatus] = useState(null);
   const { createRipple } = useRipple();
   const submitButtonRef = React.useRef(null);
   const [copied, setCopied] = useState(false);
@@ -74,7 +88,7 @@ const ContactSection = () => {
     }
 
     if (!formData.name || !formData.email || !formData.message) {
-      setSubmitStatus('error');
+      setSubmitStatus('invalid');
       return;
     }
 
@@ -90,27 +104,30 @@ const ContactSection = () => {
         body: JSON.stringify(formData),
       });
 
+      // A non-JSON body (an HTML error page from a proxy, say) throws here and is handled
+      // below as a delivery failure, which is the right classification for it.
       const data = await response.json();
 
       if (response.ok && data.success) {
         setSubmitStatus('success');
         setFormData({ name: '', email: '', message: '', company: '' });
-      } else if (data.errors && data.errors.length > 0) {
-        const errorMessages = data.errors.map(err => `${err.param}: ${err.msg}`).join(', ');
-        throw new Error(`Validation failed: ${errorMessages}`);
-      } else {
-        throw new Error(data.message || 'Failed to send message');
+        return;
       }
+
+      // 4xx means the input was rejected and re-editing it can succeed. Anything else —
+      // 5xx, 502 from the Worker when Resend is down — is not the visitor's fault and
+      // retrying the same form won't help, so offer the direct address instead.
+      throw new SubmitError(response.status >= 400 && response.status < 500 ? 'invalid' : 'failed');
     } catch (error) {
       console.error('Error sending message:', error);
 
-      // Fallback: if the backend isn't reachable, don't punish the visitor.
-      if (error instanceof TypeError || error.name === 'NetworkError') {
-        setSubmitStatus('success');
-        setFormData({ name: '', email: '', message: '', company: '' });
-      } else {
-        setSubmitStatus('error');
-      }
+      // Anything that isn't a SubmitError is a transport or runtime failure — notably
+      // fetch()'s TypeError when the request never completed (offline, DNS, CORS). That
+      // case used to be reported as success on the theory that it shouldn't "punish the
+      // visitor", but it told them a message had been sent that had not been, and cleared
+      // the form, so they lost what they wrote and had no reason to follow up. Treat it as
+      // the delivery failure it is and keep their text so the mailto fallback is useful.
+      setSubmitStatus(error instanceof SubmitError ? error.kind : 'failed');
     } finally {
       setIsSubmitting(false);
     }
@@ -119,6 +136,18 @@ const ContactSection = () => {
   const handleChange = e => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
   };
+
+  // Pre-fills the visitor's own mail client with what they already typed, so the fallback
+  // costs them a click rather than retyping the message. encodeURIComponent is load-bearing
+  // in both fields: an unencoded `&` or `?` in the body would otherwise terminate it and be
+  // read as further mailto headers.
+  const mailtoFallback = React.useMemo(() => {
+    const subject = encodeURIComponent(
+      formData.name ? `Portfolio enquiry from ${formData.name}` : 'Portfolio enquiry'
+    );
+    const body = encodeURIComponent(formData.message);
+    return `mailto:${EMAIL}?subject=${subject}&body=${body}`;
+  }, [formData.name, formData.message]);
 
   const fieldClass =
     'w-full rounded-xl border border-hairline bg-surface-2 px-4 py-3 text-slate-100 placeholder:text-slate-600 transition-colors focus:border-brand-500/60 focus:bg-surface focus:outline-none focus:ring-1 focus:ring-brand-500/40 disabled:opacity-50';
@@ -247,7 +276,7 @@ const ContactSection = () => {
                 </div>
               )}
 
-              {submitStatus === 'error' && (
+              {submitStatus === 'invalid' && (
                 <div
                   role='alert'
                   className='flex items-start gap-3 rounded-xl border border-red-500/30 bg-red-500/10 p-4'
@@ -262,6 +291,34 @@ const ContactSection = () => {
                       <li>Email: a valid email address</li>
                       <li>Message: 10–1000 characters</li>
                     </ul>
+                  </div>
+                </div>
+              )}
+
+              {/* Delivery failed and re-submitting won't help, so the only useful thing to
+                  offer is a route that doesn't depend on this API. The form keeps its
+                  contents; the mailto carries them across so nothing has to be retyped. */}
+              {submitStatus === 'failed' && (
+                <div
+                  role='alert'
+                  className='flex items-start gap-3 rounded-xl border border-amber-500/30 bg-amber-500/10 p-4'
+                >
+                  <AlertTriangle size={18} className='mt-0.5 shrink-0 text-amber-400' />
+                  <div className='min-w-0'>
+                    <p className='text-sm font-medium text-amber-200'>
+                      Your message wasn&apos;t sent.
+                    </p>
+                    <p className='mt-1 text-sm text-slate-400'>
+                      Something went wrong on my end — your text is still here, and nothing reached
+                      me. Email me directly instead:
+                    </p>
+                    <a
+                      href={mailtoFallback}
+                      className='mt-3 inline-flex items-center gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm font-semibold text-amber-100 transition-colors hover:border-amber-400/60 hover:bg-amber-500/20'
+                    >
+                      <Mail size={15} />
+                      {EMAIL}
+                    </a>
                   </div>
                 </div>
               )}

--- a/worker.js
+++ b/worker.js
@@ -418,8 +418,11 @@ export async function handleContactForm(request, env) {
       console.log('🍯 Honeypot triggered — dropping submission', {
         timestamp: new Date().toISOString(),
       });
+      // Byte-identical to the real success response below, including `delivered` — a
+      // shape difference here would be exactly the signal the honeypot exists to deny.
       return jsonResponse({
         success: true,
+        delivered: true,
         message: 'Message sent successfully! Thank you for contacting me.',
       });
     }
@@ -546,43 +549,66 @@ export async function handleContactForm(request, env) {
       timestamp: new Date().toISOString(),
     });
 
-    try {
-      const [notificationResult, autoReplyResult] = await Promise.all([
-        sendEmail(
-          'contact@aswincloud.com',
-          `New Portfolio Contact from ${name}`,
-          notificationHTML,
-          notificationText,
-          request.headers.get('host') || 'aswincloud.com',
-          env
-        ),
-        sendEmail(
-          email,
-          'Thank you for contacting me!',
-          autoReplyHTML,
-          autoReplyText,
-          request.headers.get('host') || 'aswincloud.com',
-          env
-        ),
-      ]);
+    // allSettled, not all: the two sends are not equally important, so their outcomes
+    // have to be inspected separately rather than collapsed into one rejection.
+    const [notification, autoReply] = await Promise.allSettled([
+      sendEmail(
+        'contact@aswincloud.com',
+        `New Portfolio Contact from ${name}`,
+        notificationHTML,
+        notificationText,
+        request.headers.get('host') || 'aswincloud.com',
+        env
+      ),
+      sendEmail(
+        email,
+        'Thank you for contacting me!',
+        autoReplyHTML,
+        autoReplyText,
+        request.headers.get('host') || 'aswincloud.com',
+        env
+      ),
+    ]);
 
-      console.log('✅ Both emails sent successfully:', {
-        notificationResult,
-        autoReplyResult,
-        timestamp: new Date().toISOString(),
-      });
-    } catch (emailError) {
-      console.error('❌ Email processing failed:', {
-        error: emailError.message,
-        stack: emailError.stack,
+    // The notification is the delivery. If it failed, the message reached nobody, and
+    // the previous behaviour — logging the error and answering `success: true` anyway —
+    // meant the visitor was told their message was sent when it had been dropped. They
+    // had no reason to follow up, and no copy of what they wrote. Report the failure and
+    // let the client offer the mailto fallback.
+    if (notification.status === 'rejected') {
+      console.error('❌ Notification email failed — submission not delivered:', {
+        error: notification.reason?.message,
+        autoReplyStatus: autoReply.status,
         email: redactEmail(email),
         timestamp: new Date().toISOString(),
       });
-      // Continue with success response even if email fails
+      return jsonResponse(
+        {
+          success: false,
+          delivered: false,
+          message:
+            'Your message could not be delivered. Please email contact@aswincloud.com directly.',
+        },
+        502
+      );
+    }
+
+    // The auto-reply is a courtesy to the visitor, so its failure is not theirs to act
+    // on: the message did reach its destination. Saying "failed" here would be false and
+    // would prompt a duplicate submission.
+    if (autoReply.status === 'rejected') {
+      console.warn('⚠️ Auto-reply failed but the notification was delivered:', {
+        error: autoReply.reason?.message,
+        email: redactEmail(email),
+        timestamp: new Date().toISOString(),
+      });
+    } else {
+      console.log('✅ Both emails sent successfully:', { timestamp: new Date().toISOString() });
     }
 
     return jsonResponse({
       success: true,
+      delivered: true,
       message: 'Message sent successfully! Thank you for contacting me.',
     });
   } catch (error) {


### PR DESCRIPTION
## Problem

The contact form told visitors their message was sent when it had not been, in two independent places.

**Client** (`ContactSection.jsx`) — the catch block treated `TypeError` as success:

```js
if (error instanceof TypeError || error.name === 'NetworkError') {
  setSubmitStatus('success');
  setFormData({ name: '', email: '', message: '' });
}
```

`fetch()` rejects with exactly that `TypeError` when the request never completes — offline, DNS failure, CORS. So the visitor saw "Message sent successfully", **and the form was cleared**, so they lost what they wrote and had no reason to follow up.

**Worker** (`worker.js`) — the send was wrapped in a catch that swallowed the outcome:

```js
try {
  await Promise.all([...sends]);
} catch (error) {
  console.error(...);  // Continue with success response even if email fails
}
```

Resend rejecting the notification (unverified domain, rate limit, outage) produced a `200 {success: true}`. The message reached nobody.

## Fix

Three outcomes instead of two, because the pre-existing single error state showed a *validation checklist* even when nothing about the input was wrong:

| status | meaning | copy |
|---|---|---|
| `success` | delivered | existing confirmation |
| `invalid` | 4xx — visitor can fix it by editing | existing checklist (unchanged) |
| `failed` | delivery failed, not their fault | "Your message wasn't sent" + `mailto:` fallback, **fields preserved** |

The `mailto:` link pre-fills the visitor's own client with what they already typed, so the fallback costs a click rather than retyping. `encodeURIComponent` is load-bearing on both subject and body — an unencoded `&` or `?` in their text would otherwise terminate the body and be read as further mailto headers.

Worker side, `Promise.allSettled` replaces `Promise.all`: the two sends aren't equally important, so their outcomes have to be judged separately.

- **notification rejected** → `502 {success: false, delivered: false}` with the direct address. Nobody received the message; say so.
- **auto-reply rejected only** → still `200`. The message *did* arrive; reporting failure here would be false and would prompt a duplicate submission. Logged at `warn`.

The honeypot response stays byte-identical to the real success response, `delivered` included — a shape difference there is exactly the signal the honeypot exists to deny. Asserted directly (`expect(await trapped.text()).toBe(await real.text())`).

## Verification

- **98 unit tests** pass (`contactSubmit.test.jsx` new, 30; `contactApi.test.js` extended to 57)
- **14 Playwright e2e tests** pass — `e2e/contactFailure.spec.js` uses `route.abort('failed')` for a genuine in-page fetch rejection, which is the only faithful way to trigger the reported bug
- **10 negative controls**: each fix reverted individually, expected tests failed, baseline restored and re-verified green. Control 10 showed an inner `try/catch` around `response.json()` was redundant — the outer handler already classifies a parse error as `failed` — so the dead branch was removed rather than shipped untested
- **browser-level control**: restoring the original `TypeError → success` line makes 3 of the new e2e tests fail, confirming they catch the actual bug

One test premise turned out to be wrong and was corrected rather than worked around: the inputs carry native `required`, so the browser blocks submission before `handleSubmit` runs and no in-app message appears. That test now asserts `form.checkValidity() === false` and that nothing was sent.

## Note on the base branch

Stacked on `harden/contact-api` (#166), not `main` — that PR already rewrote both `handleContactForm` and `ContactSection.jsx`, so branching off `main` would have manufactured a conflict. Retarget to `main` once #166 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)