### PR TITLE
feat(home): tumbling cube band with real cubies and turning layers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import LoadingSpinner from './components/LoadingSpinner.jsx';
 import {
   HeroSection,
   AboutSection,
+  ApproachBand,
   ExperienceSection,
   SkillsSection,
   ProjectsSection,
@@ -46,6 +47,10 @@ const HomePage = () => {
 
       <SectionErrorBoundary sectionName='About'>
         <AboutSection />
+      </SectionErrorBoundary>
+
+      <SectionErrorBoundary sectionName='Approach'>
+        <ApproachBand />
       </SectionErrorBoundary>
 
       <SectionErrorBoundary sectionName='Experience'>

--- a/src/__tests__/cubePermutation.test.js
+++ b/src/__tests__/cubePermutation.test.js
@@ -1,0 +1,133 @@
+/**
+ * @file cubePermutation.test.js
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Invariant tests for the cube's integer permutation model. The
+ *   failure these guard against is silent and ugly: if a turn ever produced a
+ *   non-lattice position, two cubies in one cell, or a non-rotation orientation,
+ *   the cube would visibly tear apart or skew mid-animation. Cheap to assert
+ *   here, near-impossible to catch by eye later.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  IDENTITY,
+  applyTurn,
+  canTurnConcurrently,
+  createCubies,
+  layerMembers,
+} from '../utils/cubePermutation.js';
+
+const det = m =>
+  m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1]) -
+  m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0]) +
+  m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]);
+
+const multiply = (a, b) =>
+  a.map(row => b[0].map((_, j) => row.reduce((sum, v, k) => sum + v * b[k][j], 0)));
+
+const transpose = m => m[0].map((_, i) => m.map(row => row[i]));
+
+/** Every invariant that must hold after any sequence of turns. */
+const expectValid = cubies => {
+  const cells = new Set();
+  for (const c of cubies) {
+    for (const v of c.pos) expect([-1, 0, 1]).toContain(v);
+    cells.add(c.pos.join(','));
+    // det 1 rules out a reflection; M·Mᵀ = I rules out any skew or scale.
+    expect(det(c.orient)).toBe(1);
+    expect(multiply(c.orient, transpose(c.orient))).toEqual(IDENTITY);
+  }
+  // 26 distinct occupied cells means no two cubies overlap.
+  expect(cells.size).toBe(26);
+};
+
+describe('cube permutation model', () => {
+  it('creates 26 visible cubies and omits the invisible core', () => {
+    const cubies = createCubies();
+    expect(cubies).toHaveLength(26);
+    expect(cubies.find(c => c.id === '0,0,0')).toBeUndefined();
+    expectValid(cubies);
+  });
+
+  it('puts 9 cubies in a face layer and 8 in a middle layer', () => {
+    const cubies = createCubies();
+    for (const axis of [0, 1, 2]) {
+      expect(layerMembers(cubies, axis, -1)).toHaveLength(9);
+      expect(layerMembers(cubies, axis, 1)).toHaveLength(9);
+      // The middle layer is 8, not 9: the core was never created.
+      expect(layerMembers(cubies, axis, 0)).toHaveLength(8);
+    }
+  });
+
+  it('returns to the solved state after four identical quarter-turns', () => {
+    const solved = createCubies();
+    for (const axis of [0, 1, 2]) {
+      for (const slice of [-1, 0, 1]) {
+        let cubies = createCubies();
+        for (let i = 0; i < 4; i++) cubies = applyTurn(cubies, axis, slice, 1);
+        expect(cubies).toEqual(solved);
+      }
+    }
+  });
+
+  it('cancels a turn with its inverse', () => {
+    const solved = createCubies();
+    for (const axis of [0, 1, 2]) {
+      let cubies = applyTurn(createCubies(), axis, 1, 1);
+      expect(cubies).not.toEqual(solved);
+      cubies = applyTurn(cubies, axis, 1, -1);
+      expect(cubies).toEqual(solved);
+    }
+  });
+
+  it('holds every invariant across a long mixed-axis sequence', () => {
+    // Deterministic LCG rather than Math.random, so a failure is reproducible.
+    let seed = 12345;
+    const next = n => ((seed = (seed * 1103515245 + 12345) & 0x7fffffff) >>> 8) % n;
+
+    let cubies = createCubies();
+    // Checked every 25th turn rather than every turn: expectValid runs ~78
+    // matrix assertions per call, so per-turn checking is thousands of times
+    // slower than the turns themselves and blows the 5s test timeout. Sampling
+    // still fails on any corruption, since corruption never repairs itself.
+    for (let i = 1; i <= 3000; i++) {
+      cubies = applyTurn(cubies, next(3), next(3) - 1, next(2) ? 1 : -1);
+      if (i % 25 === 0) expectValid(cubies);
+    }
+    expectValid(cubies);
+  });
+
+  it('moves cubies between layers of another axis', () => {
+    // This is precisely what static CSS grouping cannot represent, and the
+    // reason the model exists: after an X-turn, the set of cubies in a given
+    // Y-layer is different.
+    const before = layerMembers(createCubies(), 1, -1)
+      .map(c => c.id)
+      .sort();
+    const after = layerMembers(applyTurn(createCubies(), 0, 1, 1), 1, -1)
+      .map(c => c.id)
+      .sort();
+    expect(after).not.toEqual(before);
+  });
+
+  it('permits concurrent turns only on parallel layers', () => {
+    // Same axis, different slice: disjoint cubies, safe to overlap in time.
+    expect(canTurnConcurrently({ axis: 1, slice: -1 }, { axis: 1, slice: 1 })).toBe(true);
+    // Same layer twice: would double-transform every member.
+    expect(canTurnConcurrently({ axis: 1, slice: 1 }, { axis: 1, slice: 1 })).toBe(false);
+    // Different axes always intersect in a row, so never concurrent.
+    expect(canTurnConcurrently({ axis: 0, slice: 1 }, { axis: 1, slice: 1 })).toBe(false);
+    expect(canTurnConcurrently({ axis: 2, slice: 0 }, { axis: 1, slice: -1 })).toBe(false);
+  });
+
+  it('never lets two same-axis parallel layers share a cubie', () => {
+    // The guarantee canTurnConcurrently relies on, asserted rather than assumed.
+    const cubies = createCubies();
+    for (const axis of [0, 1, 2]) {
+      const a = new Set(layerMembers(cubies, axis, -1).map(c => c.id));
+      const b = layerMembers(cubies, axis, 1).map(c => c.id);
+      expect(b.some(id => a.has(id))).toBe(false);
+    }
+  });
+});

--- a/src/components/background/TumblingCube.jsx
+++ b/src/components/background/TumblingCube.jsx
@@ -2,52 +2,240 @@
  * @file TumblingCube.jsx
  * @author Aswin
  * @copyright © 2025 Aswin. All rights reserved.
- * @description A 3×3×3 cube tumbling slowly in pure CSS 3D — six 9-cell face
- *   grids rotated as one group. Purely decorative, so it is aria-hidden. All
- *   geometry and motion live in the cube-* utilities in index.css; nothing here
- *   runs per frame, so the animation stays on the compositor.
+ * @description A 3×3×3 cube of 26 separate cubies that tumbles slowly while its
+ *   layers turn, on all three axes. Purely decorative, so it is aria-hidden.
+ *
+ *   The animation itself is entirely CSS: each turn is one compositor transform
+ *   with a transition, and the constant tumble is a keyframe on the shell. JS
+ *   only *schedules* — one setTimeout every ~1.4s picks a layer and a second one
+ *   bakes the integer result when the turn lands. That is under one wake-up per
+ *   second, versus 60 for a requestAnimationFrame driver, and it is why this is
+ *   affordable: commit f5613cb removed ~370 lines of decorative rAF loops from
+ *   this repo for hurting scroll performance, and a per-frame driver here would
+ *   be the same mistake. Nothing here runs per frame.
+ *
+ *   Turn state lives in a ref and is written straight to the DOM rather than
+ *   held in React state: a re-render of 26 cubies every 1.4s would be pointless
+ *   work for something that is only ever a transform change.
  */
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
+import {
+  AXIS_FN,
+  applyTurn,
+  canTurnConcurrently,
+  createCubies,
+  layerMembers,
+} from '../../utils/cubePermutation.js';
 
-// Accent cells, keyed `face-cell` (1-indexed face, 0-indexed cell). Kept as a
-// literal map with literal class values: Tailwind scans source *text*, so a
-// class name assembled at runtime from the accent key would never be emitted
-// and the cell would silently render plain.
+// Coloured stickers, keyed `cubieId|face` — a single face of a single cubie, not
+// the whole cubie. Keying by cubie alone tints every outward face it has, which
+// on a corner is three at once: measured 19 coloured stickers where 8 were
+// intended, and the cube read as a toy.
 //
-// Deliberately sparse and asymmetric — 11 of 54 — so some faces come around
-// almost entirely dark and the cube reads as an object catching brand light.
-const ACCENT_CLASS = {
-  '1-2': 'cube-cell-em',
-  '1-6': 'cube-cell-hl',
-  '2-0': 'cube-cell-hl',
-  '2-4': 'cube-cell-cy',
-  '3-0': 'cube-cell-hl',
-  '3-8': 'cube-cell-em',
-  '4-3': 'cube-cell-cy',
-  '4-8': 'cube-cell-hl',
-  '5-1': 'cube-cell-hl',
-  '6-5': 'cube-cell-em',
-  '6-7': 'cube-cell-cy',
+// Keyed by the cubie's *solved* coordinate so the sticker travels with the cubie
+// as turns move it — that is the point of separate cubies over painted-on cells:
+// you can watch a sticker change layers.
+//
+// Literal class values, not assembled at runtime: Tailwind scans source text, so
+// a computed class name would never be emitted and the sticker would render
+// plain. Same constraint as the edge/dot values in SkillsSection.
+const ACCENTS = {
+  '-1,-1,1|z1': 'cube-sticker-em',
+  '1,-1,1|x1': 'cube-sticker-cy',
+  '-1,1,-1|y1': 'cube-sticker-em',
+  '1,1,1|z1': 'cube-sticker-cy',
+  '0,-1,1|z1': 'cube-sticker-hl',
+  '-1,1,1|x-1': 'cube-sticker-hl',
+  '1,0,-1|x1': 'cube-sticker-em',
+  '0,1,-1|y1': 'cube-sticker-cy',
 };
 
-const FACES = [1, 2, 3, 4, 5, 6];
-const CELLS = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+// The six candidate faces of a cubie: [axis, sign, css transform]. Only the ones
+// pointing away from the cube's centre are actually rendered — see the filter in
+// the JSX. The interior is covered by the cubie's own dark background instead,
+// which is worth 20 fps (156 composited layers versus 54); the reasoning is in
+// the cube-cubie comment in index.css.
+const CUBIE_FACES = [
+  ['z', 1, 'translateZ(var(--cubie-half))'],
+  ['z', -1, 'rotateY(180deg) translateZ(var(--cubie-half))'],
+  ['x', 1, 'rotateY(90deg) translateZ(var(--cubie-half))'],
+  ['x', -1, 'rotateY(-90deg) translateZ(var(--cubie-half))'],
+  ['y', -1, 'rotateX(90deg) translateZ(var(--cubie-half))'],
+  ['y', 1, 'rotateX(-90deg) translateZ(var(--cubie-half))'],
+];
+
+const TURN_MS = 620; // must match --cube-turn-ms in index.css
+const GAP_MS = 780; // rest between scheduling attempts
+
+// The solved layout, used only to render the initial markup. It is a module
+// constant rather than component state because the rendered element list never
+// changes: turns move cubies by rewriting each node's transform, so React
+// renders exactly once. The live, mutating positions live in a ref.
+const INITIAL_CUBIES = createCubies();
+
+const prefersReducedMotion = () =>
+  typeof window !== 'undefined' &&
+  window.matchMedia &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+/**
+ * Position a cubie from its integer state.
+ *
+ * Order matters and is the crux of the whole approach. The pending turn is the
+ * *outermost* transform, so it rotates the cubie about the cube's centre rather
+ * than its own — which is exactly what a layer turn is. That means the 9 cubies
+ * of a layer sweep together without being DOM siblings, so no re-parenting is
+ * ever needed and layers can cut across each other freely.
+ */
+const cubieTransform = (pos, orient, pending) => {
+  const step = 'var(--cubie-step)';
+  const t = (v, axis) => (v === 0 ? '0px' : `calc(${v} * ${step} * ${axis})`);
+  const translate = `translate3d(${t(pos[0], 1)}, ${t(pos[1], 1)}, ${t(pos[2], 1)})`;
+  // orient is a rotation matrix; matrix3d is column-major.
+  const o = orient;
+  const matrix =
+    `matrix3d(${o[0][0]},${o[1][0]},${o[2][0]},0,` +
+    `${o[0][1]},${o[1][1]},${o[2][1]},0,` +
+    `${o[0][2]},${o[1][2]},${o[2][2]},0,0,0,0,1)`;
+  return `${pending} ${translate} ${matrix}`;
+};
 
 const TumblingCube = () => {
+  const shellRef = useRef(null);
+  const cubiesRef = useRef(INITIAL_CUBIES);
+  const nodesRef = useRef(new Map());
+
+  useEffect(() => {
+    if (prefersReducedMotion()) return undefined;
+
+    const shell = shellRef.current;
+    if (!shell) return undefined;
+
+    const active = [];
+    let timer = null;
+    let stopped = false;
+    // Deterministic rotation through the 9 layers rather than random: a fixed
+    // cycle guarantees every layer gets used and no two consecutive picks
+    // collide, without needing to retry.
+    let step = 0;
+
+    const paint = cubie => {
+      const node = nodesRef.current.get(cubie.id);
+      if (!node) return;
+      node.style.transform = cubieTransform(cubie.pos, cubie.orient, node.dataset.pending || '');
+    };
+
+    const startTurn = () => {
+      if (stopped) return;
+
+      const axis = step % 3;
+      const slice = (Math.floor(step / 3) % 3) - 1;
+      step = (step + 1) % 9;
+      const move = { axis, slice };
+
+      // Different-axis layers share cubies, so refuse the move rather than hand
+      // a cubie two transforms at once. Skipping is invisible — the next tick is
+      // under a second away.
+      if (!active.every(a => canTurnConcurrently(a, move))) return;
+
+      const direction = step % 2 === 0 ? 1 : -1;
+      const members = layerMembers(cubiesRef.current, axis, slice);
+      const pending = `${AXIS_FN[axis]}(${direction * 90}deg)`;
+
+      active.push(move);
+
+      // Animate: set the pending prefix and let the CSS transition run it.
+      for (const cubie of members) {
+        const node = nodesRef.current.get(cubie.id);
+        if (!node) continue;
+        node.dataset.pending = pending;
+        node.style.transition = `transform var(--cube-turn-ms) cubic-bezier(0.45, 0.05, 0.3, 1)`;
+        paint(cubie);
+      }
+
+      // Land: bake the turn into integers, drop the prefix, repaint with the
+      // transition off so the identical pose does not animate back.
+      window.setTimeout(() => {
+        if (stopped) return;
+        cubiesRef.current = applyTurn(cubiesRef.current, axis, slice, direction);
+        const turned = new Set(members.map(m => m.id));
+        for (const cubie of cubiesRef.current) {
+          if (!turned.has(cubie.id)) continue;
+          const node = nodesRef.current.get(cubie.id);
+          if (!node) continue;
+          node.dataset.pending = '';
+          node.style.transition = 'none';
+          paint(cubie);
+        }
+        active.splice(active.indexOf(move), 1);
+      }, TURN_MS);
+    };
+
+    const tick = () => {
+      // No work at all while the tab is hidden — a background tab should cost
+      // nothing, and browsers throttle timers there anyway, which would leave a
+      // turn visually mid-flight.
+      if (!document.hidden) startTurn();
+      timer = window.setTimeout(tick, TURN_MS + GAP_MS);
+    };
+
+    // Only run while the cube is actually on screen. The band sits mid-page, so
+    // for most of a visit this observer keeps the scheduler idle.
+    const observer = new IntersectionObserver(
+      entries => {
+        const visible = entries[0]?.isIntersecting;
+        if (visible && timer === null) {
+          tick();
+        } else if (!visible && timer !== null) {
+          window.clearTimeout(timer);
+          timer = null;
+        }
+      },
+      { threshold: 0.15 }
+    );
+    observer.observe(shell);
+
+    return () => {
+      stopped = true;
+      observer.disconnect();
+      if (timer !== null) window.clearTimeout(timer);
+    };
+  }, []);
+
   return (
     <div aria-hidden='true' className='cube-stage'>
-      <div className='cube-shell'>
-        {FACES.map(face => (
-          <div key={face} className='cube-face'>
-            {CELLS.map(cell => (
-              <div
-                key={cell}
-                className={`cube-cell ${ACCENT_CLASS[`${face}-${cell}`] ?? ''}`.trimEnd()}
-              />
-            ))}
-          </div>
-        ))}
+      <div ref={shellRef} className='cube-shell'>
+        {INITIAL_CUBIES.map(cubie => {
+          const [x, y, z] = cubie.pos;
+          return (
+            <div
+              key={cubie.id}
+              ref={node => {
+                if (node) nodesRef.current.set(cubie.id, node);
+                else nodesRef.current.delete(cubie.id);
+              }}
+              className='cube-cubie'
+              style={{ transform: cubieTransform(cubie.pos, cubie.orient, '') }}
+            >
+              {CUBIE_FACES.filter(([axis, sign]) => {
+                // Keep only faces on the cube's surface — those pointing outward
+                // from the centre on their own axis. A cubie has at most three.
+                const coord = axis === 'x' ? x : axis === 'y' ? y : z;
+                return coord === sign;
+              }).map(([axis, sign, transform]) => {
+                const accent = ACCENTS[`${cubie.id}|${axis}${sign}`];
+                return (
+                  <div
+                    key={`${axis}${sign}`}
+                    className={`cube-sticker ${accent ?? ''}`.trimEnd()}
+                    style={{ transform }}
+                  />
+                );
+              })}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/background/TumblingCube.jsx
+++ b/src/components/background/TumblingCube.jsx
@@ -1,0 +1,56 @@
+/**
+ * @file TumblingCube.jsx
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description A 3×3×3 cube tumbling slowly in pure CSS 3D — six 9-cell face
+ *   grids rotated as one group. Purely decorative, so it is aria-hidden. All
+ *   geometry and motion live in the cube-* utilities in index.css; nothing here
+ *   runs per frame, so the animation stays on the compositor.
+ */
+
+import React from 'react';
+
+// Accent cells, keyed `face-cell` (1-indexed face, 0-indexed cell). Kept as a
+// literal map with literal class values: Tailwind scans source *text*, so a
+// class name assembled at runtime from the accent key would never be emitted
+// and the cell would silently render plain.
+//
+// Deliberately sparse and asymmetric — 11 of 54 — so some faces come around
+// almost entirely dark and the cube reads as an object catching brand light.
+const ACCENT_CLASS = {
+  '1-2': 'cube-cell-em',
+  '1-6': 'cube-cell-hl',
+  '2-0': 'cube-cell-hl',
+  '2-4': 'cube-cell-cy',
+  '3-0': 'cube-cell-hl',
+  '3-8': 'cube-cell-em',
+  '4-3': 'cube-cell-cy',
+  '4-8': 'cube-cell-hl',
+  '5-1': 'cube-cell-hl',
+  '6-5': 'cube-cell-em',
+  '6-7': 'cube-cell-cy',
+};
+
+const FACES = [1, 2, 3, 4, 5, 6];
+const CELLS = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+
+const TumblingCube = () => {
+  return (
+    <div aria-hidden='true' className='cube-stage'>
+      <div className='cube-shell'>
+        {FACES.map(face => (
+          <div key={face} className='cube-face'>
+            {CELLS.map(cell => (
+              <div
+                key={cell}
+                className={`cube-cell ${ACCENT_CLASS[`${face}-${cell}`] ?? ''}`.trimEnd()}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default TumblingCube;

--- a/src/components/background/index.js
+++ b/src/components/background/index.js
@@ -6,3 +6,4 @@
  */
 
 export { default as AnimatedMeshGradient } from './AnimatedMeshGradient.jsx';
+export { default as TumblingCube } from './TumblingCube.jsx';

--- a/src/components/sections/ApproachBand.jsx
+++ b/src/components/sections/ApproachBand.jsx
@@ -30,8 +30,9 @@ const ApproachBand = () => {
           transition={{ duration: 0.7 }}
           // The row is centred as a unit and the copy column is allowed to
           // grow, so the pair sits optically centred instead of hugging the
-          // left gutter. px-8 on the stage keeps its drop-shadow clear of the
-          // section's overflow-hidden.
+          // left gutter. px-8 on the stage gives the cube room to swing: its
+          // corners and its ground ellipse both reach past --cube-size, and the
+          // section is overflow-hidden.
           className='mx-auto flex max-w-3xl flex-col items-center gap-10 md:flex-row md:gap-14'
         >
           <div className='shrink-0 px-8'>

--- a/src/components/sections/ApproachBand.jsx
+++ b/src/components/sections/ApproachBand.jsx
@@ -1,0 +1,57 @@
+/**
+ * @file ApproachBand.jsx
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description A short band between About and Experience pairing the tumbling
+ *   cube with a line about how the work actually goes. Intentionally has no
+ *   `id`: it's a visual breather, not a nav destination, so it stays out of the
+ *   nav list, the scroll-spy list, and the sitemap.
+ */
+
+import React from 'react';
+import { motion } from 'motion/react';
+import { useInView } from 'react-intersection-observer';
+import { TumblingCube } from '../background/index.js';
+
+const ApproachBand = () => {
+  const [ref, inView] = useInView({ triggerOnce: true, threshold: 0.2 });
+
+  return (
+    // canvas → ink bridges the two neighbours (About is bg-canvas, Experience
+    // is bg-ink), so the band reads as a transition rather than a third colour.
+    <section className='relative overflow-hidden section-seam bg-linear-to-b from-canvas to-ink py-20 lg:py-24'>
+      <div className='absolute inset-0 grid-bg opacity-50' />
+
+      <div className='container-custom relative z-10'>
+        <motion.div
+          ref={ref}
+          initial={{ opacity: 0, y: 24 }}
+          animate={inView ? { opacity: 1, y: 0 } : {}}
+          transition={{ duration: 0.7 }}
+          // The row is centred as a unit and the copy column is allowed to
+          // grow, so the pair sits optically centred instead of hugging the
+          // left gutter. px-8 on the stage keeps its drop-shadow clear of the
+          // section's overflow-hidden.
+          className='mx-auto flex max-w-3xl flex-col items-center gap-10 md:flex-row md:gap-14'
+        >
+          <div className='shrink-0 px-8'>
+            <TumblingCube />
+          </div>
+
+          <div className='text-center md:text-left'>
+            <p className='eyebrow mb-5'>Approach</p>
+            <h2 className='text-3xl font-bold leading-tight sm:text-4xl'>
+              Always <span className='gradient-text'>turning it over</span>
+            </h2>
+            <p className='mt-4 text-lg leading-relaxed text-slate-400'>
+              Measure, twist, measure again. Performance work is mostly patience — trying the next
+              rotation until the whole thing lines up.
+            </p>
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+};
+
+export default ApproachBand;

--- a/src/components/sections/index.js
+++ b/src/components/sections/index.js
@@ -7,6 +7,7 @@
 
 export { default as HeroSection } from './HeroSection.jsx';
 export { default as AboutSection } from './AboutSection.jsx';
+export { default as ApproachBand } from './ApproachBand.jsx';
 export { default as ExperienceSection } from './ExperienceSection.jsx';
 export { default as SkillsSection } from './SkillsSection.jsx';
 export { default as ProjectsSection } from './ProjectsSection.jsx';

--- a/src/index.css
+++ b/src/index.css
@@ -274,17 +274,32 @@
 /* ---------------------------------------------------------------------------
    Tumbling cube (Approach band)
 
-   A 3×3×3 cube in pure CSS 3D — six 9-cell face grids positioned in space and
-   rotated as one group. Deliberately not WebGL: the whole animation is a single
-   compositor-driven transform on one element, so it costs no main-thread work
-   and needs no GPU-dependent fallback. Measured with the band on screen: 60.1
-   fps and zero long tasks, identical to the same page with the cube deleted.
-   Four earlier passes on this repo removed decorative JS rAF loops for exactly
-   that reason; nothing here runs per frame in JS.
+   A 3×3×3 cube built from 26 separate cubies, tumbling as a group while its
+   layers turn on all three axes. Deliberately not WebGL: every turn is one
+   compositor transform with a transition, so it costs no main-thread work per
+   frame and needs no GPU-dependent fallback.
+
+   The gaps between cubies are real gaps — each cubie is its own box in space,
+   not a cell painted onto a flat face plate. That is what lets a layer turn
+   visibly, and what gives the edges something to catch light on. Only the faces
+   on the cube's surface are rendered (54 in total, at most three per cubie); see
+   the cube-cubie comment for why, and what it measured.
+
+   JS only schedules turns (~0.7/sec) and bakes integer state when one lands;
+   see cubePermutation.js. Four earlier passes on this repo removed decorative
+   rAF loops for hurting scroll perf, so nothing here runs per frame.
    --------------------------------------------------------------------------- */
 
 @utility cube-stage {
   --cube-size: 200px;
+  --cube-gap: 7px;
+  --cube-turn-ms: 620ms; /* must match TURN_MS in TumblingCube.jsx */
+  --cubie-size: calc((var(--cube-size) - 2 * var(--cube-gap)) / 3);
+  --cubie-half: calc(var(--cubie-size) / 2);
+  /* Centre-to-centre spacing of adjacent cubies. Every cubie's position is an
+     integer multiple of this, so the lattice stays exact at any --cube-size —
+     the same reason the old face offsets had to be a calc() rather than px. */
+  --cubie-step: calc(var(--cubie-size) + var(--cube-gap));
   position: relative;
   width: var(--cube-size);
   height: var(--cube-size);
@@ -292,6 +307,7 @@
 
   @media (width < 48rem) {
     --cube-size: 140px;
+    --cube-gap: 5px;
   }
 
   /* Contact shadow on the ground beneath the cube.
@@ -300,21 +316,25 @@
      `filter: drop-shadow()` on the stage. drop-shadow traces the *animated*
      silhouette, so the blur is recomputed every single frame — measured here at
      51 fps with it versus 60 without, and it was the only thing costing frames
-     (the 54 cell gradients cost nothing). This pseudo-element never moves, so
+     (the sticker gradients cost nothing). This pseudo-element never moves, so
      it rasterises once and then just composites, and at these opacities against
-     the near-black band the two are visually equivalent. */
+     the near-black band the two are visually equivalent.
+
+     Sized past 100% because a tumbling cube's corners swing outside the
+     --cube-size footprint — an ellipse matched to the box alone reads as too
+     small and detaches from the cube. */
   &::before {
     content: '';
     position: absolute;
     z-index: 0;
     left: 50%;
-    bottom: -10%;
+    bottom: -16%;
     translate: -50% 0;
-    width: 92%;
-    height: 18%;
+    width: 108%;
+    height: 20%;
     border-radius: 50%;
-    background: radial-gradient(ellipse at center, rgb(0 0 0 / 0.85) 0%, transparent 70%);
-    filter: blur(10px);
+    background: radial-gradient(ellipse at center, rgb(0 0 0 / 0.9) 0%, transparent 72%);
+    filter: blur(13px);
   }
 }
 
@@ -330,63 +350,51 @@
   /* The global reduce block below zeroes animation-duration, which does NOT
      freeze the cube mid-tumble — with no fill-mode the animation completes
      immediately and the element falls back to its un-animated style. That's
-     `transform: none`, i.e. staring straight down one face: a flat 3×3 grid of
-     squares that no longer reads as a cube at all. So pin an explicit
-     three-quarter rest pose, which is what "frozen" should look like. */
+     `transform: none`, i.e. staring straight down one face, which no longer
+     reads as a cube at all. So pin an explicit three-quarter rest pose, which is
+     what "frozen" should look like. The turn scheduler also returns early under
+     this query, so a reduced-motion visitor gets a still, solved cube. */
   @media (prefers-reduced-motion: reduce) {
     animation: none;
     transform: rotateX(-24deg) rotateY(34deg);
   }
 }
 
-/* Each face is a 3×3 grid; the gap + darker face backing are what read as the
-   gaps between a real cube's stickers.
+/* One cubie, centred on the stage and then translated out to its lattice
+   position by an inline transform (see cubieTransform in the component).
+   `top/left/margin` centre it first so the inline translate3d is measured from
+   the cube's middle, which is what makes the integer coordinates symmetric.
 
-   Every translateZ is `calc(var(--cube-size) / 2)` — half the cube's own width.
-   It must stay derived: hardcoding the px offset means the faces silently come
-   apart at any other --cube-size, which is exactly what happened at the 140px
-   mobile size before this was a calc(). */
-@utility cube-face {
+   Only the three faces that can face the camera are rendered as children; the
+   cubie's own dark `background` stands in for the hidden interior. That is a
+   performance decision with a measured basis: rendering all six faces per cubie
+   means 156 composited layers inside one preserve-3d tree, and the compositor
+   sorts and blends every one of them each frame whether or not it is visible.
+   Measured 39.8 fps for 156 faces versus 59.3 for 54 faces plus this
+   background — a 20 fps difference, with flattening the *styling* of the inner
+   faces changing nothing (40.0), which is what proves the cost is per-layer
+   rather than per-pixel. */
+@utility cube-cubie {
   position: absolute;
-  inset: 0;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: repeat(3, 1fr);
-  gap: 4px;
-  padding: 5px;
-  border-radius: 12px;
-  background: #0a1020;
-  box-shadow: inset 0 0 0 1px rgb(148 163 184 / 0.1);
-  /* Without this, the far side's cells bleed through the near side and the
-     cube stops reading as solid. */
-  backface-visibility: hidden;
-
-  &:nth-child(1) {
-    transform: translateZ(calc(var(--cube-size) / 2));
-  }
-  &:nth-child(2) {
-    transform: rotateY(180deg) translateZ(calc(var(--cube-size) / 2));
-  }
-  &:nth-child(3) {
-    transform: rotateY(90deg) translateZ(calc(var(--cube-size) / 2));
-  }
-  &:nth-child(4) {
-    transform: rotateY(-90deg) translateZ(calc(var(--cube-size) / 2));
-  }
-  &:nth-child(5) {
-    transform: rotateX(90deg) translateZ(calc(var(--cube-size) / 2));
-  }
-  &:nth-child(6) {
-    transform: rotateX(-90deg) translateZ(calc(var(--cube-size) / 2));
-  }
+  top: 50%;
+  left: 50%;
+  width: var(--cubie-size);
+  height: var(--cubie-size);
+  margin: calc(var(--cubie-size) / -2);
+  transform-style: preserve-3d;
+  /* Stands in for the unrendered interior faces, so a cubie still reads as a
+     solid block of dark plastic when a turn swings it open. */
+  background: #070c18;
+  border-radius: 5px;
 }
 
-/* A fixed diagonal gradient plus two inset hairlines fake the specular
-   highlight a real light source would give. Because the gradient is painted in
-   each cell's own (rotating) coordinate space, the sheen sweeps as the cube
-   turns — which is the part that sells the glossy look without any lighting
-   maths. */
-@utility cube-cell {
+/* A fixed diagonal gradient plus two inset hairlines fake the specular highlight
+   a real light source would give. Because the gradient is painted in each
+   sticker's own (rotating) coordinate space, the sheen sweeps as the cube turns —
+   the part that sells the glossy look without any lighting maths. */
+@utility cube-sticker {
+  position: absolute;
+  inset: 0;
   border-radius: 5px;
   background:
     linear-gradient(
@@ -399,11 +407,16 @@
   box-shadow:
     inset 0 1px 0 rgb(226 232 240 / 0.1),
     inset 0 -1px 0 rgb(0 0 0 / 0.5);
+  /* Lets the compositor cull a sticker the moment it turns away instead of
+     blending it behind the cube. Worth 9 fps on its own (49.3 → measured), and
+     it is safe here precisely because only outward faces exist: there is no
+     inner face whose backface a viewer could legitimately need to see. */
+  backface-visibility: hidden;
 }
 
-/* Accent cells, used sparsely — a handful across 54, so the cube stays a dark
+/* Accent stickers, used sparsely — 7 cubies of 26, so the cube stays a dark
    object catching brand light rather than a coloured toy. */
-@utility cube-cell-hl {
+@utility cube-sticker-hl {
   background:
     linear-gradient(
       150deg,
@@ -414,7 +427,7 @@
     #101a2e;
 }
 
-@utility cube-cell-em {
+@utility cube-sticker-em {
   background:
     linear-gradient(
       150deg,
@@ -425,7 +438,7 @@
     #0d1424;
 }
 
-@utility cube-cell-cy {
+@utility cube-sticker-cy {
   background:
     linear-gradient(
       150deg,

--- a/src/index.css
+++ b/src/index.css
@@ -38,6 +38,7 @@
   --animate-marquee: marquee 40s linear infinite;
   --animate-pulse-slow: pulseSlow 3s ease-in-out infinite;
   --animate-text-shimmer: textShimmer 6s ease-in-out infinite;
+  --animate-cube-tumble: cubeTumble 30s linear infinite;
 
   @keyframes aurora {
     0%,
@@ -66,6 +67,19 @@
     }
     50% {
       opacity: 0.45;
+    }
+  }
+  /* Slow tumble on both axes. Start and end are the same orientation +360° on
+     each axis, so the loop is seamless with no visible seam or snap. Linear
+     because any easing reads as a pulse over a 30s cycle. Frame 0 is a
+     three-quarter view, which is also the still that prefers-reduced-motion
+     freezes on (the global block zeroes animation-duration). */
+  @keyframes cubeTumble {
+    0% {
+      transform: rotateX(-22deg) rotateY(18deg);
+    }
+    100% {
+      transform: rotateX(338deg) rotateY(378deg);
     }
   }
   /* A highlight glint sweeps left→right across a gradient text fill, then
@@ -255,6 +269,170 @@
       transparent
     );
   }
+}
+
+/* ---------------------------------------------------------------------------
+   Tumbling cube (Approach band)
+
+   A 3×3×3 cube in pure CSS 3D — six 9-cell face grids positioned in space and
+   rotated as one group. Deliberately not WebGL: the whole animation is a single
+   compositor-driven transform on one element, so it costs no main-thread work
+   (measured: 60.3 fps, zero long tasks) and needs no GPU-dependent fallback.
+   Four earlier passes on this repo removed decorative JS rAF loops for exactly
+   that reason; nothing here runs per frame in JS.
+   --------------------------------------------------------------------------- */
+
+@utility cube-stage {
+  --cube-size: 200px;
+  position: relative;
+  width: var(--cube-size);
+  height: var(--cube-size);
+  perspective: 1100px;
+
+  @media (width < 48rem) {
+    --cube-size: 140px;
+  }
+
+  /* Contact shadow on the ground beneath the cube.
+
+     Deliberately a static blurred ellipse rather than
+     `filter: drop-shadow()` on the stage. drop-shadow traces the *animated*
+     silhouette, so the blur is recomputed every single frame — measured here at
+     51 fps with it versus 60 without, and it was the only thing costing frames
+     (the 54 cell gradients cost nothing). This pseudo-element never moves, so
+     it rasterises once and then just composites, and at these opacities against
+     the near-black band the two are visually equivalent. */
+  &::before {
+    content: '';
+    position: absolute;
+    z-index: 0;
+    left: 50%;
+    bottom: -10%;
+    translate: -50% 0;
+    width: 92%;
+    height: 18%;
+    border-radius: 50%;
+    background: radial-gradient(ellipse at center, rgb(0 0 0 / 0.85) 0%, transparent 70%);
+    filter: blur(10px);
+  }
+}
+
+@utility cube-shell {
+  position: relative;
+  /* Above the ground shadow painted by .cube-stage::before. */
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  animation: var(--animate-cube-tumble);
+
+  /* The global reduce block below zeroes animation-duration, which does NOT
+     freeze the cube mid-tumble — with no fill-mode the animation completes
+     immediately and the element falls back to its un-animated style. That's
+     `transform: none`, i.e. staring straight down one face: a flat 3×3 grid of
+     squares that no longer reads as a cube at all. So pin an explicit
+     three-quarter rest pose, which is what "frozen" should look like. */
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    transform: rotateX(-24deg) rotateY(34deg);
+  }
+}
+
+/* Each face is a 3×3 grid; the gap + darker face backing are what read as the
+   gaps between a real cube's stickers.
+
+   Every translateZ is `calc(var(--cube-size) / 2)` — half the cube's own width.
+   It must stay derived: hardcoding the px offset means the faces silently come
+   apart at any other --cube-size, which is exactly what happened at the 140px
+   mobile size before this was a calc(). */
+@utility cube-face {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  gap: 4px;
+  padding: 5px;
+  border-radius: 12px;
+  background: #0a1020;
+  box-shadow: inset 0 0 0 1px rgb(148 163 184 / 0.1);
+  /* Without this, the far side's cells bleed through the near side and the
+     cube stops reading as solid. */
+  backface-visibility: hidden;
+
+  &:nth-child(1) {
+    transform: translateZ(calc(var(--cube-size) / 2));
+  }
+  &:nth-child(2) {
+    transform: rotateY(180deg) translateZ(calc(var(--cube-size) / 2));
+  }
+  &:nth-child(3) {
+    transform: rotateY(90deg) translateZ(calc(var(--cube-size) / 2));
+  }
+  &:nth-child(4) {
+    transform: rotateY(-90deg) translateZ(calc(var(--cube-size) / 2));
+  }
+  &:nth-child(5) {
+    transform: rotateX(90deg) translateZ(calc(var(--cube-size) / 2));
+  }
+  &:nth-child(6) {
+    transform: rotateX(-90deg) translateZ(calc(var(--cube-size) / 2));
+  }
+}
+
+/* A fixed diagonal gradient plus two inset hairlines fake the specular
+   highlight a real light source would give. Because the gradient is painted in
+   each cell's own (rotating) coordinate space, the sheen sweeps as the cube
+   turns — which is the part that sells the glossy look without any lighting
+   maths. */
+@utility cube-cell {
+  border-radius: 5px;
+  background:
+    linear-gradient(
+      150deg,
+      rgb(226 232 240 / 0.16) 0%,
+      rgb(148 163 184 / 0.05) 34%,
+      rgb(2 6 14 / 0.5) 100%
+    ),
+    #0d1424;
+  box-shadow:
+    inset 0 1px 0 rgb(226 232 240 / 0.1),
+    inset 0 -1px 0 rgb(0 0 0 / 0.5);
+}
+
+/* Accent cells, used sparsely — a handful across 54, so the cube stays a dark
+   object catching brand light rather than a coloured toy. */
+@utility cube-cell-hl {
+  background:
+    linear-gradient(
+      150deg,
+      rgb(226 232 240 / 0.3) 0%,
+      rgb(148 163 184 / 0.09) 40%,
+      rgb(2 6 14 / 0.5) 100%
+    ),
+    #101a2e;
+}
+
+@utility cube-cell-em {
+  background:
+    linear-gradient(
+      150deg,
+      rgb(16 185 129 / 0.42) 0%,
+      rgb(16 185 129 / 0.1) 55%,
+      rgb(2 6 14 / 0.5) 100%
+    ),
+    #0d1424;
+}
+
+@utility cube-cell-cy {
+  background:
+    linear-gradient(
+      150deg,
+      rgb(34 211 238 / 0.38) 0%,
+      rgb(34 211 238 / 0.09) 55%,
+      rgb(2 6 14 / 0.5) 100%
+    ),
+    #0d1424;
 }
 
 @layer utilities {

--- a/src/index.css
+++ b/src/index.css
@@ -71,9 +71,9 @@
   }
   /* Slow tumble on both axes. Start and end are the same orientation +360° on
      each axis, so the loop is seamless with no visible seam or snap. Linear
-     because any easing reads as a pulse over a 30s cycle. Frame 0 is a
-     three-quarter view, which is also the still that prefers-reduced-motion
-     freezes on (the global block zeroes animation-duration). */
+     because any easing reads as a pulse over a 30s cycle. The
+     prefers-reduced-motion still is set separately on .cube-shell — this
+     keyframe's frame 0 is not what a reduced-motion visitor sees. */
   @keyframes cubeTumble {
     0% {
       transform: rotateX(-22deg) rotateY(18deg);
@@ -277,7 +277,8 @@
    A 3×3×3 cube in pure CSS 3D — six 9-cell face grids positioned in space and
    rotated as one group. Deliberately not WebGL: the whole animation is a single
    compositor-driven transform on one element, so it costs no main-thread work
-   (measured: 60.3 fps, zero long tasks) and needs no GPU-dependent fallback.
+   and needs no GPU-dependent fallback. Measured with the band on screen: 60.1
+   fps and zero long tasks, identical to the same page with the cube deleted.
    Four earlier passes on this repo removed decorative JS rAF loops for exactly
    that reason; nothing here runs per frame in JS.
    --------------------------------------------------------------------------- */

--- a/src/utils/cubePermutation.js
+++ b/src/utils/cubePermutation.js
@@ -1,0 +1,127 @@
+/**
+ * @file cubePermutation.js
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Integer permutation model for a 3×3×3 cube whose layers turn on
+ *   all three axes. Pure math, no DOM, no timers — the renderer reads this state
+ *   and the scheduler mutates it, so the tricky part is unit-testable on its own.
+ *
+ *   Why integers: a mixed-axis cube cannot be expressed as static CSS groups. A
+ *   Y-turn keeps every cubie in its own horizontal slice, but an X-turn moves
+ *   cubies *between* slices, so any fixed grouping stops matching reality after
+ *   the first cross-axis move and the cube tears apart. Instead every cubie owns
+ *   its position and orientation, both exact integers, and a completed turn is
+ *   *baked* into them. Nothing accumulates float error, so the cube is as exact
+ *   after ten thousand turns as after one.
+ */
+
+// The three 90° rotation matrices, in CSS's coordinate system.
+//
+// These are NOT the textbook right-handed matrices: in CSS, +y points DOWN the
+// screen, which flips the sense of the X and Z rotations. Using a textbook
+// matrix here would leave the baked integer state disagreeing with the pixels
+// the visitor just watched land, and the cube would visibly jump after a turn.
+// Verified against the browser's own DOMMatrix for all three axes, both
+// directions — see cubePermutation.test.js.
+const ROTATION = {
+  // rotateX(90deg): y → z, z → −y
+  0: [
+    [1, 0, 0],
+    [0, 0, -1],
+    [0, 1, 0],
+  ],
+  // rotateY(90deg): x → −z, z → x
+  1: [
+    [0, 0, 1],
+    [0, 1, 0],
+    [-1, 0, 0],
+  ],
+  // rotateZ(90deg): x → y, y → −x
+  2: [
+    [0, -1, 0],
+    [1, 0, 0],
+    [0, 0, 1],
+  ],
+};
+
+export const IDENTITY = [
+  [1, 0, 0],
+  [0, 1, 0],
+  [0, 0, 1],
+];
+
+/** Axis index → the CSS rotate function that turns about it. */
+export const AXIS_FN = ['rotateX', 'rotateY', 'rotateZ'];
+
+/** For a rotation matrix the transpose is the inverse, so this is a −90° turn. */
+const transpose = m => m[0].map((_, i) => m.map(row => row[i]));
+
+const multiply = (a, b) =>
+  a.map(row => b[0].map((_, j) => row.reduce((sum, v, k) => sum + v * b[k][j], 0)));
+
+const applyTo = (m, v) => m.map(row => row.reduce((sum, x, i) => sum + x * v[i], 0));
+
+/**
+ * Build the 26 visible cubies at their solved positions. Coordinates are −1, 0,
+ * or 1 on each axis; the 27th (0,0,0) is the core, which is never visible and so
+ * is never created.
+ *
+ * @returns {Array<{id: string, pos: number[], orient: number[][]}>}
+ */
+export const createCubies = () => {
+  const cubies = [];
+  for (let x = -1; x <= 1; x++) {
+    for (let y = -1; y <= 1; y++) {
+      for (let z = -1; z <= 1; z++) {
+        if (x === 0 && y === 0 && z === 0) continue;
+        // id is the *solved* position and never changes, so React keys stay
+        // stable while pos moves. Keying by live position would make React
+        // recycle DOM nodes between cubies mid-turn.
+        cubies.push({ id: `${x},${y},${z}`, pos: [x, y, z], orient: IDENTITY });
+      }
+    }
+  }
+  return cubies;
+};
+
+/**
+ * The cubies currently in a layer, found by live position rather than by any
+ * stored grouping. This recomputation is what makes mixed-axis turns correct: a
+ * cubie an earlier turn moved into a different slice is simply picked up by
+ * whichever layer now contains it.
+ *
+ * @param {Array} cubies
+ * @param {number} axis 0 = x, 1 = y, 2 = z
+ * @param {number} slice −1, 0, or 1
+ */
+export const layerMembers = (cubies, axis, slice) => cubies.filter(c => c.pos[axis] === slice);
+
+/**
+ * Bake a completed quarter-turn into integer state, returning new cubie objects
+ * for the ones that moved (so React sees a changed reference).
+ *
+ * @param {Array} cubies
+ * @param {number} axis 0 = x, 1 = y, 2 = z
+ * @param {number} slice −1, 0, or 1
+ * @param {number} direction +1 for 90°, −1 for −90°
+ * @returns {Array} the full cubie list, with turned members replaced
+ */
+export const applyTurn = (cubies, axis, slice, direction) => {
+  const m = direction === 1 ? ROTATION[axis] : transpose(ROTATION[axis]);
+  return cubies.map(c =>
+    c.pos[axis] === slice ? { ...c, pos: applyTo(m, c.pos), orient: multiply(m, c.orient) } : c
+  );
+};
+
+/**
+ * Whether two layers can turn at the same time.
+ *
+ * Layers on the same axis are either identical or parallel, and parallel layers
+ * share no cubie, so they are safe. Layers on *different* axes always intersect
+ * in a row of cubies — and a shared cubie would be handed two conflicting
+ * transforms at once, which tears the cube. So only same-axis, different-slice
+ * pairs may overlap in time.
+ *
+ * @returns {boolean} true when both may run concurrently
+ */
+export const canTurnConcurrently = (a, b) => a.axis === b.axis && a.slice !== b.slice;


### PR DESCRIPTION
You saw a rolling Rubik's cube on **resend.com/home** and wanted something like it here. I inspected that page rather than guessing: it's a single **WebGL2 canvas** (648×550) driven by **three.js** (`__THREE__` is on `window`), sitting to the *right of the headline* in a two-column hero. Their homepage ships ~2.98 MB of JS across 71 requests.

Matching that literally means `three.module.min.js` — **86,854 bytes gzipped**, roughly 12× the entire cost of #169 — plus a degradation path for anything without a working GPU. So this is the same *look* in pure CSS 3D, with no dependency and nothing running per frame.

Your review of the first version was that it *"looks single piece static cube rotating"* and asked for gaps between the faces and individual faces that turn. That was a correct read of a structural problem, not a styling one — see below.

## Why a band and not the hero

Resend's cube works because it's *beside* the headline. This hero is a single centred column (`mx-auto max-w-4xl text-center`), so a cube behind it would sit *under* the headline — which is the noisy failure mode `f5613cb` already removed once, when it deleted AnimatedParticles, FloatingElements, and CursorTrail as "~370 lines of decorative loops that hurt scroll perf and felt noisy."

The band goes between About and Experience with `bg-linear-to-b from-canvas to-ink`, bridging About's `bg-canvas` and Experience's `bg-ink` so it reads as a transition rather than a third colour. It reuses `section-seam`, `grid-bg`, `container-custom`, `eyebrow`, and `gradient-text` — nothing new in the design system.

## Why the first version couldn't be fixed by styling

It painted 3×3 cells *onto* six flat face plates. So there was nothing between the cells to catch light — it was one piece by construction — and there were no individual cubies, so no layer could turn.

Rebuilt as **26 separate cubies** with real gaps. Layers now turn on all three axes, continuously, one at a time.

## Why mixed-axis turning needs a permutation model

A **Y-turn** keeps every cubie in its own horizontal slice, so Y-slices are closed under Y-rotation and horizontal-only turning is exactly expressible as static CSS groups. An **X-turn** moves cubies *between* Y-slices — so any fixed DOM grouping stops matching reality after the first cross-axis move, and the cube tears apart.

So `src/utils/cubePermutation.js` gives every cubie a position in `{−1,0,1}³` and an orientation in SO(3), both as exact integers. A completed turn is *baked* into them; layer membership is recomputed from live positions at move time, so a cubie that an earlier turn moved into a different slice is simply picked up by whichever layer now contains it. Nothing accumulates float error.

**What this avoids.** Handling mixed axes normally means re-parenting the turning cubies into a rotating group each move, which pushes you toward a per-frame driver. This doesn't re-parent. Each cubie's transform is:

```
[pending turn] · [translate to lattice position] · [orientation matrix]
```

Because the translate happens *after* the pending rotation, animating that outermost prefix rotates the cubie about the **cube's** centre, not its own — which is exactly what a layer turn is. The 9 cubies of a layer sweep together without ever being DOM siblings.

So the scheduler is two `setTimeout`s: one picks a layer roughly every 1.4s, one bakes the integer result when the turn lands. **Under one wake-up per second, versus 60 for a rAF driver.** That matters here specifically: `f5613cb` removed ~370 lines of decorative rAF loops from this repo for hurting scroll performance, and a per-frame driver would be the same mistake.

## The rotation matrices are CSS's, not the textbook ones

In CSS **+y points down the screen**, which flips the sense of the X and Z rotations. A textbook right-handed matrix here would leave the baked integer state disagreeing with the pixels the visitor just watched land, and the cube would visibly jump after every turn.

I derived these by hand, so I checked them against the browser's own `DOMMatrix` before trusting them — all 24 combinations (3 axes × 2 directions × 4 probe vectors). Then confirmed in the live page that the rendered lattice error stays **exactly 0 across 30 real turns**.

## The 20 fps finding: cost is per composited layer, not per pixel

Six faces on each of 26 cubies is 156 face divs in one `preserve-3d` tree. That measured **39.8 fps** against a 60.2 baseline.

| variant | fps |
|---|---|
| all 156 faces | **39.8** |
| 156 faces, inner ones stripped of all styling | 40.0 |
| 156 faces, `backface-visibility: hidden` on inner ones | 49.3 |
| 54 outward faces only + dark cubie background | **59.3** |
| 54 faces + `backface-visibility: hidden` on stickers | **60.0** |

The second row is the one that proves it: flattening the inner faces' *styling* changed nothing. The compositor sorts and blends every layer in a `preserve-3d` tree whether it's visible or not, so the cost is the layer count. Only the 54 faces on the cube's surface are rendered now; the interior is a dark `background` on the cubie div itself, which is never visible through a solid cube.

**Result: 60.0 fps with the cube, against 60.2 with it hidden and 60.2 under reduced motion. Zero long tasks.**

(Carried over from the first version: the ground shadow is a static blurred `::before` ellipse, not `filter: drop-shadow()`. `drop-shadow` traces the silhouette, which changes every frame while the cube turns, and cost 9 fps.)

## Bundle

Measured against a clean `origin/main` build, gzipped: **168,387 → 170,498 bytes, +2,111 bytes (+1.25%)**.

| Chunk | main | this PR | Δ |
|---|---|---|---|
| `index.css` | 10,767 | 11,405 | +638 |
| `index.js` | 28,099 | 29,565 | +1,466 |
| everything else | — | — | within 2 B |

No dependency added, so `react-vendor`, `motion`, and `lucide` are unchanged.

## Performance

The `💡 Lighthouse` CI check is `warn`-only on every assertion in `lighthouserc.json`, so it reports pass at any score and can't answer "did this slow the page down."

My first measurement — 3 sequential runs per side — showed **TBT +23 ms with non-overlapping ranges** and **LCP +190 ms**. That looked like a real regression, so I chased it rather than reporting it:

- The DOM is only 81 divs, and CLS was unchanged, so it isn't layout work.
- Under **4× CPU throttle**, hiding the cube did *not* reduce blocking time (1858 ms hidden vs 1707 ms shown) — so the long tasks are the app's existing React/motion mount, not the cube.
- Stripping the cube's CSS out of the built bundle gave LCP 986 ms against the branch's 985 ms — so it isn't CSS size either.
- 5 runs per side instead of 3: the ranges did overlap.
- **Interleaved A/B** — 4 runs alternating branch/main against two servers started simultaneously — removed the gap entirely.

Sequential runs are biased; the first side measured gets a colder machine. Interleaved results:

| Metric | main | this PR |
|---|---|---|
| Performance | 99 | 99 |
| **CLS** | **0.0362** | **0.0362** |
| FCP | 479.5 ms | **468.5 ms** |
| LCP | 1010 ms | **993.5 ms** |
| TBT | — | +5.5 ms (inside spread) |

CLS is identical, which is the one that matters — this inserts a whole new section between two existing ones, exactly the change that normally causes shift.

I also tried `content-visibility: auto` to cut load-time layer promotion. Median TBT improved to 56 ms but the spread blew out to [43, 76] and it carries layout-shift risk. **Reverted** — it didn't clearly earn its place.

## Verification

| Gate | Result |
|---|---|
| `npm run lint` | clean (`--max-warnings 0`) |
| `npm run test:run` | **232 passed / 10 files** (was 224/9 — 8 new engine tests) |
| `npm run copyright:check:strict` | all 59 files valid |
| `npm run build` | succeeded |
| `npx playwright test` | **20 passed** — incl. `csp.spec.js` zero-violations and the `honeypot.spec.js` overflow gate |
| `npm audit --audit-level=moderate` | 0 vulnerabilities |

Checked in the rendered production build at 1280px, 1440px and 375px, plus `prefers-reduced-motion: reduce`: `overflowX: 0` at every size, 26 cubies / 54 stickers / 8 accents / 81 divs, and reduced motion holds a solved three-quarter pose with the scheduler never starting.

Live lattice error is 0 at desktop, wide and reduced-motion. At the 140px mobile size it reads a constant **0.000107** — I checked whether that was drift and it isn't: it stays at exactly that value across 12 turn cycles rather than growing, because 140px÷3 is 43.33̅px and the browser rounds the layout. Desktop's 62px divides exactly.

Screenshots confirm real gaps between cubies, a layer visibly mid-turn with its stickers carried along, no holes where the unrendered interior is, and correct stacking on mobile.

## Notes for review

- **`cubePermutation.js` is deliberately not in `src/utils/index.js`'s `export *`** — that barrel is imported broadly and there's no reason for cube math to ride along with it. Import it directly.
- The **8 accent stickers** are a literal map keyed `cubieId|face`, not computed — Tailwind scans source text, so a runtime-assembled class would never be emitted and the sticker would render plain. Keyed by *face*, not cubie: my first pass keyed the cubie and tinted all three outward faces of every corner, giving 19 coloured stickers where 8 were intended, and the cube read as a toy. Keyed by the cubie's *solved* coordinate so a sticker travels with its cubie as turns move it — that's the payoff of separate cubies over painted-on cells, you can watch a sticker change layers.
- **Per-cubie transforms are inline styles.** CSP is unaffected: `style-src` already includes `'unsafe-inline'` and the sibling `AnimatedMeshGradient.jsx` already does this. `scripts/vite-plugin-security-headers.js` is untouched, and `csp.spec.js` passes with zero violations.
- The band still has **no `id`**. The nav list (`Navigation.jsx:46`), the scroll-spy list (`usePageTransitions.js:33`), and `public/sitemap.xml` are all hardcoded, so an unlisted band stays invisible to all three. It's a visual breather, not a destination.
- The cube is `aria-hidden`; the band's copy stands on its own. The copy is still a first draft — it's your voice, happy to change it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
