### PR TITLE
fix(csp): unblock the Cloudflare Web Analytics beacon

### DIFF
--- a/scripts/vite-plugin-security-headers.js
+++ b/scripts/vite-plugin-security-headers.js
@@ -24,6 +24,20 @@ const GTM = 'https://www.googletagmanager.com';
 const CHATWOOT = 'https://support.aswincloud.com';
 const FONTS_CSS = 'https://fonts.googleapis.com';
 const FONTS_FILES = 'https://fonts.gstatic.com';
+// Cloudflare Web Analytics. The proxy injects this script into every HTML
+// response, so it is not optional here — without it the beacon is blocked and
+// analytics silently collects nothing.
+//
+// The trailing slash is load-bearing. Cloudflare's own docs say to allowlist
+// `…/beacon.min.js`, but the real src is `…/beacon.min.js/<version-hash>`, and a
+// CSP path with no trailing slash must match the URL path *exactly*. Verified
+// against the live beacon URL in Chromium: the documented form is blocked, this
+// one is allowed. Scoped to the path rather than the whole origin so the grant
+// covers only the beacon.
+const CF_BEACON = 'https://static.cloudflareinsights.com/beacon.min.js/';
+// The beacon POSTs its RUM payload here (XHR to /cdn-cgi/rum), on the apex
+// hostname rather than the static. one it is served from.
+const CF_BEACON_RUM = 'https://cloudflareinsights.com';
 // GA4 spreads telemetry across regional subdomains (region1.google-analytics.com,
 // etc.), so these have to be wildcards.
 const GA_BEACONS = [
@@ -90,6 +104,7 @@ export function buildCsp(html) {
       ...(handlerHashes.length ? ["'unsafe-hashes'", ...handlerHashes] : []),
       GTM,
       CHATWOOT,
+      CF_BEACON,
     ],
     // 'unsafe-inline' is a considered trade-off: the Chatwoot SDK injects a
     // <style> element at runtime whose contents change with their releases, so it
@@ -100,7 +115,7 @@ export function buildCsp(html) {
     'style-src': ["'self'", "'unsafe-inline'", FONTS_CSS],
     'img-src': ["'self'", 'data:', 'https:'],
     'font-src': ["'self'", 'data:', FONTS_FILES],
-    'connect-src': ["'self'", ...GA_BEACONS, CHATWOOT],
+    'connect-src': ["'self'", ...GA_BEACONS, CHATWOOT, CF_BEACON_RUM],
     // The Chatwoot widget renders its panel in an iframe on its own origin.
     'frame-src': ["'self'", CHATWOOT],
     'object-src': ["'none'"],

--- a/src/__tests__/securityHeaders.test.js
+++ b/src/__tests__/securityHeaders.test.js
@@ -164,6 +164,27 @@ describe('buildCsp', () => {
     expect(csp['frame-src']).toContain('https://support.aswincloud.com');
   });
 
+  it('allowlists the Cloudflare Web Analytics beacon, path-scoped and with its trailing slash', () => {
+    const csp = parse(buildCsp(html));
+    const beacon = 'https://static.cloudflareinsights.com/beacon.min.js/';
+
+    // Cloudflare's proxy injects the beacon into every HTML response, so this is
+    // not opt-in: without the grant the script is blocked and analytics records
+    // nothing, with no failure anywhere except the browser console.
+    expect(csp['script-src']).toContain(beacon);
+    // The beacon POSTs its RUM payload to the apex host, not the static. one.
+    expect(csp['connect-src']).toContain('https://cloudflareinsights.com');
+
+    // The trailing slash is the whole fix and is easy to "tidy" away. A CSP path
+    // without one must match exactly, and the real src carries a version segment
+    // (…/beacon.min.js/v4513226…), so the un-slashed form — which is what
+    // Cloudflare's own docs recommend — does not match and the script stays
+    // blocked. Verified in Chromium against the live URL.
+    expect(csp['script-src']).not.toContain('https://static.cloudflareinsights.com/beacon.min.js');
+    // Path-scoped rather than origin-wide, so the grant covers only the beacon.
+    expect(csp['script-src']).not.toContain('https://static.cloudflareinsights.com');
+  });
+
   it('locks down the directives that limit injection blast radius', () => {
     const csp = parse(buildCsp(html));
     expect(csp['default-src']).toEqual(["'self'"]);


### PR DESCRIPTION
Found while verifying the cube on the live site after #170 merged — unrelated to that PR, and pre-existing since the CSP hardening in #165.

## The bug

Cloudflare's proxy injects its Web Analytics beacon into every HTML response, but `static.cloudflareinsights.com` was never in `script-src`. So production has been doing this on every page load:

```
Loading the script 'https://static.cloudflareinsights.com/beacon.min.js/v4513226...'
violates the following Content Security Policy directive: "script-src 'self' ...
https://www.googletagmanager.com https://support.aswincloud.com".
```

**Web Analytics has been collecting nothing.** Nothing fails visibly — the page renders fine, no check goes red, the only symptom is a console error. That's why it survived since #165.

## The trailing slash is the fix, not a typo

Cloudflare's own documentation says to allowlist:

```
script-src ... https://static.cloudflareinsights.com/beacon.min.js
```

That doesn't work here. The injected `src` carries a version segment — `.../beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496` — and **a CSP source with a path but no trailing slash must match the URL path exactly**. With a trailing slash it becomes a prefix match, which is what this needs.

I tested all three candidate forms in Chromium against the real beacon URL rather than trusting the doc:

| `script-src` value | result |
|---|---|
| `.../beacon.min.js` (Cloudflare's documented form) | **blocked** |
| `.../beacon.min.js/` | **allowed** |
| `https://static.cloudflareinsights.com` (origin-wide) | allowed |

Went with the path-scoped form: it works, and it grants only the beacon rather than anything Cloudflare might ever serve from that host.

## `connect-src` needs the apex host too

The beacon POSTs its RUM payload by XHR to `https://cloudflareinsights.com/cdn-cgi/rum` — the **apex** hostname, not the `static.` one it's served from. Granting only `script-src` loads the script and then fails its single network call, which is the same outcome with extra steps. Observed directly in the test above; the first run showed the script loading 200 and then the XHR failing.

## Verification

End to end, serving the **real generated `dist/_headers`** through `scripts/serve-with-headers.js` and loading the live beacon against it:

```json
{
  "servedCspGrantsBeacon": true,
  "beaconTagInjected": true,
  "beaconNetworkResponses": ["200 https://static.cloudflareinsights.com/beacon.min.js/v4513226..."],
  "cspViolations": []
}
```

| Gate | Result |
|---|---|
| `npm run lint` | clean (`--max-warnings 0`) |
| `npm run test:run` | **233 passed / 10 files** (was 232 — one new) |
| `npm run copyright:check:strict` | all 59 files valid |
| `npm run build` | succeeded |
| `npx playwright test` | **20 passed** — incl. `csp.spec.js` zero-violations |
| `npm audit --audit-level=moderate` | 0 vulnerabilities |

## The new test is mutation-checked

The trailing slash is exactly the kind of detail a later edit would "tidy" away, so the test asserts it with **negative** assertions — that the un-slashed and origin-wide forms are *absent*. A test that only checked `toContain(beacon)` would pass with the origin-wide grant too.

I verified those assertions aren't vacuous by breaking the source three ways; each fails the test:

| Mutation | Test |
|---|---|
| trailing slash removed | ✗ fails |
| origin-wide instead of path-scoped | ✗ fails |
| `connect-src` grant dropped | ✗ fails |
| (restored) | ✓ 30 passed |

## Note on scope

This only touches `scripts/vite-plugin-security-headers.js`, which generates `dist/_headers` for **static asset** responses. `worker.js` keeps its own much stricter `default-src 'none'` policy for `/api/*` — untouched, and correctly so, since no beacon runs there.

`script-src` still has no `'unsafe-inline'`, and the inline-script hashes are unchanged.

## Alternative, if you'd rather not

If you don't use Web Analytics, the other fix is turning auto-injection off in the Cloudflare dashboard — that removes the console error without granting anything. This PR assumes you want the analytics working; say the word and I'll close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
