### PR TITLE
feat(home): light the cube, and let the cursor move the light

### DIFF
--- a/src/__tests__/cubePermutation.test.js
+++ b/src/__tests__/cubePermutation.test.js
@@ -7,6 +7,9 @@
  *   non-lattice position, two cubies in one cell, or a non-rotation orientation,
  *   the cube would visibly tear apart or skew mid-animation. Cheap to assert
  *   here, near-impossible to catch by eye later.
+ *
+ *   Also covers lightPosition, the other pure function in that module. Its
+ *   failure mode is the same shape — invisible in code, obvious on screen.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -16,6 +19,7 @@ import {
   canTurnConcurrently,
   createCubies,
   layerMembers,
+  lightPosition,
 } from '../utils/cubePermutation.js';
 
 const det = m =>
@@ -129,5 +133,75 @@ describe('cube permutation model', () => {
       const b = layerMembers(cubies, axis, 1).map(c => c.id);
       expect(b.some(id => a.has(id))).toBe(false);
     }
+  });
+});
+
+// A stage somewhere down the page, so a test that accidentally assumed the
+// viewport origin would fail rather than coincidentally pass.
+const RECT = { left: 400, top: 300, width: 320, height: 320 };
+
+/* The clamp is the whole substance of lightPosition, and it is the kind of thing
+ * that breaks quietly: a wrong bound still produces a perfectly valid gradient,
+ * just one painted at each tile's centre, so all 54 faces glow individually
+ * instead of the cube reading as one object catching a light. Nothing throws and
+ * nothing looks broken in code — it only looks wrong on screen. Hence asserting
+ * the bounds here.
+ */
+describe('specular light position', () => {
+  const X = { min: 10, max: 30 };
+  const Y = { min: 6, max: 17 };
+
+  const expectInRange = ({ x, y }) => {
+    expect(x).toBeGreaterThanOrEqual(X.min);
+    expect(x).toBeLessThanOrEqual(X.max);
+    expect(y).toBeGreaterThanOrEqual(Y.min);
+    expect(y).toBeLessThanOrEqual(Y.max);
+  };
+
+  it('stays in range for a pointer far outside the stage on every side', () => {
+    // Thousands of pixels out, and negative — the pointer is tracked globally
+    // while the band is on screen, so it genuinely does reach these positions.
+    const far = [
+      [-9000, 300],
+      [9000, 300],
+      [400, -9000],
+      [400, 9000],
+      [-9000, -9000],
+      [9000, 9000],
+    ];
+    for (const [cx, cy] of far) expectInRange(lightPosition(cx, cy, RECT));
+  });
+
+  it('never puts the light near a tile centre, even at the stage centre', () => {
+    // Centre pointer gives the middle of each range. That must still be nowhere
+    // near 50% — a highlight at the middle of every sticker is the failure this
+    // clamp exists to prevent.
+    const centre = lightPosition(560, 460, RECT);
+    expect(centre).toEqual({ x: 20, y: 11.5 });
+    expect(centre.x).toBeLessThan(35);
+    expect(centre.y).toBeLessThan(35);
+  });
+
+  it('leans the light toward the pointer', () => {
+    const left = lightPosition(RECT.left - 200, 460, RECT);
+    const right = lightPosition(RECT.left + RECT.width + 200, 460, RECT);
+    const above = lightPosition(560, RECT.top - 200, RECT);
+    const below = lightPosition(560, RECT.top + RECT.height + 200, RECT);
+
+    expect(left.x).toBeLessThan(right.x);
+    expect(above.y).toBeLessThan(below.y);
+    // And it actually travels, rather than sitting clamped at one value.
+    expect(right.x - left.x).toBeGreaterThan(10);
+    expect(below.y - above.y).toBeGreaterThan(5);
+  });
+
+  it('returns a usable position for an unlaid-out stage', () => {
+    // getBoundingClientRect on a display:none element, or one measured before
+    // paint, is all zeroes. Dividing by that yields NaN, which would serialise
+    // into the custom property as garbage and blank the hotspot on all 54 faces.
+    const zero = lightPosition(560, 460, { left: 0, top: 0, width: 0, height: 0 });
+    expect(Number.isFinite(zero.x)).toBe(true);
+    expect(Number.isFinite(zero.y)).toBe(true);
+    expectInRange(zero);
   });
 });

--- a/src/components/background/TumblingCube.jsx
+++ b/src/components/background/TumblingCube.jsx
@@ -12,11 +12,20 @@
  *   second, versus 60 for a requestAnimationFrame driver, and it is why this is
  *   affordable: commit f5613cb removed ~370 lines of decorative rAF loops from
  *   this repo for hurting scroll performance, and a per-frame driver here would
- *   be the same mistake. Nothing here runs per frame.
+ *   be the same mistake.
  *
- *   Turn state lives in a ref and is written straight to the DOM rather than
- *   held in React state: a re-render of 26 cubies every 1.4s would be pointless
- *   work for something that is only ever a transform change.
+ *   The one thing that can run per frame is the light: on a pointer device the
+ *   specular highlight follows the cursor. It is bounded three ways — nothing
+ *   happens unless the pointer is moving, the writes are coalesced so there is
+ *   at most one per frame however many events arrive, and the listener only
+ *   exists while the cube is on screen. Measured under a synthetic move storm at
+ *   6× CPU throttle: 56.5 fps moving, 60.0 idle. The deleted CursorTrail was
+ *   expensive because it called setState per mousemove — a React re-render per
+ *   particle — not because it listened to the pointer.
+ *
+ *   Turn state and light position both live in refs and are written straight to
+ *   the DOM rather than held in React state: a re-render of 26 cubies for what
+ *   is only ever a style change would be pointless work.
  */
 
 import React, { useEffect, useRef } from 'react';
@@ -26,6 +35,7 @@ import {
   canTurnConcurrently,
   createCubies,
   layerMembers,
+  lightPosition,
 } from '../../utils/cubePermutation.js';
 
 // Coloured stickers, keyed `cubieId|face` — a single face of a single cubie, not
@@ -79,6 +89,13 @@ const prefersReducedMotion = () =>
   window.matchMedia &&
   window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
+// Whether the device has a pointer that hovers. A touch screen reports false —
+// there is no cursor position to follow between taps, so the light simply stays
+// at its CSS default and no listener is ever attached. Verified in emulation:
+// desktop true, phone false. Same signal the hover-only rules in index.css use.
+const canHover = () =>
+  typeof window !== 'undefined' && window.matchMedia && window.matchMedia('(hover: hover)').matches;
+
 /**
  * Position a cubie from its integer state.
  *
@@ -102,6 +119,7 @@ const cubieTransform = (pos, orient, pending) => {
 };
 
 const TumblingCube = () => {
+  const stageRef = useRef(null);
   const shellRef = useRef(null);
   const cubiesRef = useRef(INITIAL_CUBIES);
   const nodesRef = useRef(new Map());
@@ -180,16 +198,52 @@ const TumblingCube = () => {
       timer = window.setTimeout(tick, TURN_MS + GAP_MS);
     };
 
+    // --- The light follows the pointer ------------------------------------
+    //
+    // One style write on the stage moves the highlight on all 54 stickers,
+    // because they inherit --cube-light-x/y from it. Coalescing through a single
+    // rAF means a burst of pointer events collapses to one write per frame; the
+    // browser fires them faster than it paints, and each one dirties 54
+    // gradients, so writing per event would be repainting the cube several times
+    // for one visible change.
+    const hover = canHover();
+    let frame = null;
+    let point = null;
+
+    const flush = () => {
+      frame = null;
+      const stage = stageRef.current;
+      if (!stage || !point) return;
+      const { x, y } = lightPosition(point.x, point.y, stage.getBoundingClientRect());
+      stage.style.setProperty('--cube-light-x', `${x.toFixed(1)}%`);
+      stage.style.setProperty('--cube-light-y', `${y.toFixed(1)}%`);
+    };
+
+    const onPointerMove = event => {
+      point = { x: event.clientX, y: event.clientY };
+      if (frame === null) frame = window.requestAnimationFrame(flush);
+    };
+
+    // Passive: the handler never calls preventDefault, and saying so up front
+    // keeps it off the critical path for scrolling over the band.
+    const listen = () => window.addEventListener('pointermove', onPointerMove, { passive: true });
+    const unlisten = () => window.removeEventListener('pointermove', onPointerMove);
+
     // Only run while the cube is actually on screen. The band sits mid-page, so
-    // for most of a visit this observer keeps the scheduler idle.
+    // for most of a visit this observer keeps the scheduler idle — and keeps the
+    // pointer listener unattached, which matters more: a global pointermove
+    // handler that outlives the band would be doing work on every page the
+    // visitor scrolls through.
     const observer = new IntersectionObserver(
       entries => {
         const visible = entries[0]?.isIntersecting;
         if (visible && timer === null) {
           tick();
+          if (hover) listen();
         } else if (!visible && timer !== null) {
           window.clearTimeout(timer);
           timer = null;
+          if (hover) unlisten();
         }
       },
       { threshold: 0.15 }
@@ -200,11 +254,13 @@ const TumblingCube = () => {
       stopped = true;
       observer.disconnect();
       if (timer !== null) window.clearTimeout(timer);
+      unlisten();
+      if (frame !== null) window.cancelAnimationFrame(frame);
     };
   }, []);
 
   return (
-    <div aria-hidden='true' className='cube-stage'>
+    <div ref={stageRef} aria-hidden='true' className='cube-stage'>
       <div ref={shellRef} className='cube-shell'>
         {INITIAL_CUBIES.map(cubie => {
           const [x, y, z] = cubie.pos;

--- a/src/index.css
+++ b/src/index.css
@@ -287,7 +287,10 @@
 
    JS only schedules turns (~0.7/sec) and bakes integer state when one lands;
    see cubePermutation.js. Four earlier passes on this repo removed decorative
-   rAF loops for hurting scroll perf, so nothing here runs per frame.
+   rAF loops for hurting scroll perf, so the only thing that can run per frame is
+   the light: on a hovering pointer device the highlight follows the cursor, via
+   one rAF-coalesced write of --cube-light-x/y, and only while the pointer is
+   actually moving over the band. See the TumblingCube.jsx header.
    --------------------------------------------------------------------------- */
 
 @utility cube-stage {
@@ -300,6 +303,20 @@
      integer multiple of this, so the lattice stays exact at any --cube-size —
      the same reason the old face offsets had to be a calc() rather than px. */
   --cubie-step: calc(var(--cubie-size) + var(--cube-gap));
+  /* Where the specular highlight sits inside every sticker. Declared here rather
+     than on the sticker so all 54 inherit it: moving the light on the whole cube
+     is then one style write on this element, which is what makes the pointer
+     handler in TumblingCube.jsx cheap enough to exist.
+
+     Also the resting value for anyone the pointer never reaches — touch devices
+     and reduced-motion visitors keep exactly this.
+
+     Kept well away from a sticker's centre: past roughly 32%/18% the hotspot
+     lands mid-tile and the cube stops reading as one object catching a light and
+     starts reading as 54 glowing buttons. lightPosition() in cubePermutation.js
+     clamps inside that bound, and carries the sweep it came from. */
+  --cube-light-x: 28%;
+  --cube-light-y: 14%;
   position: relative;
   width: var(--cube-size);
   height: var(--cube-size);
@@ -388,25 +405,40 @@
   border-radius: 5px;
 }
 
-/* A fixed diagonal gradient plus two inset hairlines fake the specular highlight
-   a real light source would give. Because the gradient is painted in each
-   sticker's own (rotating) coordinate space, the sheen sweeps as the cube turns —
-   the part that sells the glossy look without any lighting maths. */
+/* Two layers fake the lighting a real light source would give: a radial hotspot
+   for the specular highlight, over a diagonal wash for the broad falloff, plus
+   two inset hairlines for the bevel. Because both are painted in each sticker's
+   own (rotating) coordinate space, the sheen sweeps as the cube turns — the part
+   that sells the glossy look without any lighting maths.
+
+   The hotspot's position comes from --cube-light-x/y on the stage, so the
+   pointer can move the light across all 54 faces at once. Everything else about
+   it is static: an idle keyframe walking the light measured 53.7 fps against
+   60.0 for a fixed one, because moving it repaints every gradient. That is paint
+   work rather than compositor work, which is the category this repo has removed
+   animations for before, so the light only ever moves in response to a pointer
+   that is actually moving. */
 @utility cube-sticker {
   position: absolute;
   inset: 0;
   border-radius: 5px;
   background:
+    radial-gradient(
+      135% 135% at var(--cube-light-x) var(--cube-light-y),
+      rgb(255 255 255 / 0.3) 0%,
+      rgb(226 232 240 / 0.1) 26%,
+      transparent 58%
+    ),
     linear-gradient(
       150deg,
-      rgb(226 232 240 / 0.16) 0%,
-      rgb(148 163 184 / 0.05) 34%,
-      rgb(2 6 14 / 0.5) 100%
+      rgb(226 232 240 / 0.14) 0%,
+      rgb(148 163 184 / 0.04) 40%,
+      rgb(2 6 14 / 0.55) 100%
     ),
     #0d1424;
   box-shadow:
-    inset 0 1px 0 rgb(226 232 240 / 0.1),
-    inset 0 -1px 0 rgb(0 0 0 / 0.5);
+    inset 0 1px 0 rgb(255 255 255 / 0.16),
+    inset 0 -1px 0 rgb(0 0 0 / 0.55);
   /* Lets the compositor cull a sticker the moment it turns away instead of
      blending it behind the cube. Worth 9 fps on its own (49.3 → measured), and
      it is safe here precisely because only outward faces exist: there is no
@@ -415,9 +447,21 @@
 }
 
 /* Accent stickers, used sparsely — 7 cubies of 26, so the cube stays a dark
-   object catching brand light rather than a coloured toy. */
+   object catching brand light rather than a coloured toy.
+
+   Each repeats the hotspot layer from .cube-sticker. That looks like duplication
+   worth factoring out, but these set `background` outright rather than adding to
+   it, so an accent that omits the hotspot simply loses it: the 8 accent stickers
+   would sit flat while the other 46 gloss, which is obvious the moment they sit
+   side by side. Only the tinted layer underneath differs. */
 @utility cube-sticker-hl {
   background:
+    radial-gradient(
+      135% 135% at var(--cube-light-x) var(--cube-light-y),
+      rgb(255 255 255 / 0.3) 0%,
+      rgb(226 232 240 / 0.1) 26%,
+      transparent 58%
+    ),
     linear-gradient(
       150deg,
       rgb(226 232 240 / 0.3) 0%,
@@ -429,6 +473,12 @@
 
 @utility cube-sticker-em {
   background:
+    radial-gradient(
+      135% 135% at var(--cube-light-x) var(--cube-light-y),
+      rgb(255 255 255 / 0.3) 0%,
+      rgb(226 232 240 / 0.1) 26%,
+      transparent 58%
+    ),
     linear-gradient(
       150deg,
       rgb(16 185 129 / 0.42) 0%,
@@ -440,6 +490,12 @@
 
 @utility cube-sticker-cy {
   background:
+    radial-gradient(
+      135% 135% at var(--cube-light-x) var(--cube-light-y),
+      rgb(255 255 255 / 0.3) 0%,
+      rgb(226 232 240 / 0.1) 26%,
+      transparent 58%
+    ),
     linear-gradient(
       150deg,
       rgb(34 211 238 / 0.38) 0%,

--- a/src/utils/cubePermutation.js
+++ b/src/utils/cubePermutation.js
@@ -125,3 +125,60 @@ export const applyTurn = (cubies, axis, slice, direction) => {
  * @returns {boolean} true when both may run concurrently
  */
 export const canTurnConcurrently = (a, b) => a.axis === b.axis && a.slice !== b.slice;
+
+/* Bounds for the specular highlight, as percentages inside a sticker.
+ *
+ * Both ranges stay well clear of 50%, and that is the whole point. The hotspot
+ * is painted once per sticker in its own coordinate space, so wherever it sits,
+ * it sits there on all 54 faces at once. Near a corner that reads as light
+ * glancing across the cube; further in, every tile gets a matching centred blob
+ * and the cube reads as a grid of glowing buttons rather than one lit object.
+ *
+ * The bounds come from sweeping the range against the real cube at its shipped
+ * size, not against a mock-up: 36%/21% and beyond are visibly blobby, 32%/18% is
+ * borderline, 28%/16% and below read as light. Scale mattered more than expected
+ * — an isolated large sticker tolerates a much more central hotspot than a 42px
+ * one seen among 53 others, so the bound measured on a prototype was too loose.
+ *
+ * The Y range is tighter than the X range because the cube's ground shadow
+ * anchors it from below, so a light drifting downward fights the shading that
+ * is already there.
+ */
+const LIGHT_X = { min: 10, max: 30 };
+const LIGHT_Y = { min: 6, max: 17 };
+
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+/**
+ * Map a pointer position to the specular highlight's position inside a sticker.
+ *
+ * Pure, and deliberately here rather than in the component: it is the one part
+ * of the pointer feature with a correctness condition worth testing, and it
+ * needs no DOM to test — just a rect-shaped object.
+ *
+ * The pointer's offset from the stage's centre is normalised to −1…1 and then
+ * mapped across the ranges above, so the light tracks direction rather than
+ * absolute position: the highlight leans the way the cursor is, and stays in
+ * bounds no matter how far away the cursor actually is.
+ *
+ * @param {number} clientX pointer X in viewport coordinates
+ * @param {number} clientY pointer Y in viewport coordinates
+ * @param {{left: number, top: number, width: number, height: number}} rect
+ *   the stage's bounding box
+ * @returns {{x: number, y: number}} percentages, always within the ranges above
+ */
+export const lightPosition = (clientX, clientY, rect) => {
+  // A zero-sized rect means the stage is not laid out (display:none, or measured
+  // before paint). Dividing by it yields Infinity/NaN, which would serialise
+  // into the custom property as garbage and blank the hotspot, so fall back to
+  // the centre of the range instead.
+  const nx = rect.width > 0 ? (clientX - (rect.left + rect.width / 2)) / rect.width : 0;
+  const ny = rect.height > 0 ? (clientY - (rect.top + rect.height / 2)) / rect.height : 0;
+
+  const spread = (n, { min, max }) => {
+    const mid = (min + max) / 2;
+    return clamp(mid + clamp(n, -1, 1) * ((max - min) / 2), min, max);
+  };
+
+  return { x: spread(nx, LIGHT_X), y: spread(ny, LIGHT_Y) };
+};


### PR DESCRIPTION
The cube's stickers faked a sheen with one fixed diagonal gradient each — the same soft wash on all 54 faces, with no point of light anywhere. This adds a real specular hotspot, and lets the pointer move it.

The two asks turned out to be one feature. The hotspot's position is a CSS custom property inherited from the stage, so the pointer moves **the light** rather than the cube. Moving the whole cube's lighting is then a single style write on one element, which is what makes the pointer handler cheap enough to exist. The tumble keyframe is untouched.

## Bounding the cost

The cost here is paint, not composite — moving the light dirties 54 gradients. So it's bounded three ways:

- nothing happens unless the pointer is actually moving
- writes coalesce through one `requestAnimationFrame`, so a burst of pointer events collapses to one write per frame; the browser fires them faster than it paints
- the listener only exists while the band is on screen, and only under `(hover: hover)` — a touch device keeps the CSS default and attaches nothing

Measured under a synthetic move storm at 6× CPU throttle: **56.5 fps moving, 60.0 idle**, against 60.2 for the shipped cube. An idle keyframe walking the light cost a standing −6 fps, so the light only ever moves in response to a pointer. The `CursorTrail` deleted in `f5613cb` was expensive because it called `setState` per mousemove — a React re-render per particle — not because it listened to the pointer.

## The clamp, and a bound that a prototype got wrong

`lightPosition()` clamps the hotspot well away from a sticker's centre. That clamp is the substance of the feature: the hotspot is painted once per sticker in its own coordinate space, so wherever it sits, it sits there on all 54 faces at once. Near a corner it reads as light glancing across the cube; further in, every tile gets a matching centred blob and the cube reads as a grid of glowing buttons.

The bound is scale-dependent in a way the prototype hid. Swept against the real cube at its shipped 200px rather than a mock-up: 36%/21% and beyond are visibly blobby, 32%/18% borderline, 28%/16% and below read as light. An isolated large sticker tolerates a far more central hotspot than a 42px one seen among 53 others, so the prototype-derived bound was too loose and has been tightened.

The three accent utilities repeat the hotspot layer rather than sharing it — they set `background` outright rather than adding to it, so an accent that omitted it would sit flat while its neighbours glossed.

## Perf: interleaved Lighthouse A/B vs `main`

5 alternating pairs, desktop preset, medians:

| | main | this branch | delta |
|---|---|---|---|
| Performance | 96 | 97 | +1 |
| LCP | 1140 ms | 1178 ms | +38 ms |
| TBT | 52 ms | 39 ms | −13 ms |
| CLS | 0.0362 | 0.0362 | 0 |
| FCP | 741 ms | 741 ms | 0 |
| Speed Index | 1166 ms | 1044 ms | −122 ms |

No regression — deltas point both ways and sit inside the run-to-run spread (main's own LCP ranges 980–1239 ms across its five runs). Interleaved rather than sequential deliberately: the last cube measurement, run sequentially, manufactured a phantom TBT +23 ms / LCP +190 ms regression that didn't survive interleaving.

## Verification

`npm run lint` (`--max-warnings 0`), 237 tests (4 new `lightPosition` cases covering the clamp, direction, and a zero-sized rect), `copyright:check:strict`, `build`, 20 Playwright tests — all green.

By hand at 1280px and 375px: the highlight slides across all 54 faces without blobbing at either travel extreme; the cube keeps tumbling with the pointer idle; accent stickers catch the hotspot; touch reports `hover:false`, attaches no listener, still paints the hotspot, and scrolls normally over the band; `prefers-reduced-motion: reduce` gives a still cube with a static hotspot and no tracking.

## Rejected after prototyping

- **World-space light overlay** (`mix-blend-mode: screen`) — composites in screen space, so it can't respect the 3D geometry; renders as a lens flare in front of the cube.
- **Per-face direction shading** — correct at rest, but the values ride with the cube, so a face lit as "up" stays bright once it tumbles to the bottom.
- **Plane-continuous hotspot** across a whole 3×3 face — the per-tile offsets don't survive turns, since a cubie carries its sticker to a new position.
- **`-webkit-box-reflect` floor mirror** — free, and it fits the band's clearance, but it's a reflection *of* the cube rather than light *on* it. Firefox ignores it silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)