### PR TITLE
feat(seo): put the hero headline in the served HTML

### DIFF
--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -17,10 +17,15 @@ test('app mounts and renders real content', async ({ page }) => {
   expect(resp?.ok()).toBeTruthy();
   await expect(page).toHaveTitle(/Aswin/i);
 
-  // Deterministic proof React actually rendered: #root gains child elements
-  // (a blank/failed mount leaves the static <div id="root"></div> empty).
+  // Deterministic proof React actually rendered. "#root has children" used to
+  // be that proof, but no longer is: the build now prerenders a static hero
+  // into #root (scripts/vite-plugin-prerender-hero.js), so it has children even
+  // if the bundle never executes. What still distinguishes the two is that
+  // createRoot() clears the container — so the disappearance of #hero-shell is
+  // the mount signal, and it fails closed if React dies.
   const root = page.locator('#root');
   await expect(root).toBeVisible();
+  await expect(page.locator('#hero-shell')).toHaveCount(0, { timeout: 15_000 });
   await expect
     .poll(async () => await root.locator(':scope > *').count(), { timeout: 15_000 })
     .toBeGreaterThan(0);
@@ -36,4 +41,27 @@ test('no uncaught exceptions from the app on load', async ({ page }) => {
   await page.goto('/', { waitUntil: 'domcontentloaded' });
   await expect(page.locator('#root > *').first()).toBeVisible({ timeout: 15_000 });
   expect(pageErrors, 'uncaught exceptions on load').toEqual([]);
+});
+
+// The whole point of the prerender is the no-JS reader, so that is what this
+// asserts — with scripts off, not merely "before the bundle runs". Without it
+// the shell could regress to empty and every other test would still pass,
+// because they all run JS.
+test.describe('prerendered hero (JavaScript disabled)', () => {
+  test.use({ javaScriptEnabled: false });
+
+  test('the headline and intro are in the served HTML', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    const h1 = page.locator('h1');
+    await expect(h1).toHaveCount(1);
+    await expect(h1).toBeVisible();
+    await expect(h1).toHaveText(/AI accelerators/i);
+
+    // Visible, not merely present: a prerender that ships the copy at opacity 0
+    // is worse than none — it reads as cloaking and helps no one.
+    await expect(h1).toHaveCSS('opacity', '1');
+
+    await expect(page.locator('#hero-shell p').last()).toContainText(/profile, benchmark/i);
+  });
 });

--- a/scripts/vite-plugin-prerender-hero.js
+++ b/scripts/vite-plugin-prerender-hero.js
@@ -1,0 +1,101 @@
+/**
+ * @file vite-plugin-prerender-hero.js
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Writes the hero's <h1> and intro paragraph into `<div id="root">`
+ * at build time, so the served HTML contains the page's first meaningful content
+ * instead of an empty shell.
+ *
+ * Why this exists: the site is a client-rendered SPA, so the 8 KB shell had no
+ * <h1> at all — the headline was created by React after the bundle parsed.
+ * Lighthouse executes JS and scored SEO 100 regardless, which is exactly what
+ * made this easy to miss. Crawlers and link unfurlers that don't run JS saw
+ * nothing but <div id="root"></div>.
+ *
+ * Why not render the real component with renderToStaticMarkup: HeroSection's
+ * entrance animation means every motion element serialises with
+ * `style="opacity:0"` — ten of them. That publishes the headline as invisible
+ * text, which is worse than publishing none: it reads as cloaking, and a reader
+ * with JS disabled sees a blank page either way. Stripping the inline styles
+ * back out afterwards would leave the build depending on the exact shape of
+ * motion's SSR output. So this emits its own small, static markup, and the
+ * words come from src/data/heroContent.js, which HeroSection also reads — there
+ * is one copy of the sentences, not two.
+ *
+ * React's createRoot() clears the container before its first render, so this
+ * markup is replaced wholesale on mount. It is never hydrated and never has to
+ * match what React produces, which is what keeps it free to be simpler than the
+ * real hero.
+ *
+ * Ordering note: this runs in `transformIndexHtml` so the injected markup is
+ * part of the HTML that vite-plugin-security-headers hashes at closeBundle. The
+ * two don't actually interact today — this adds no <script> and no inline event
+ * handler, so it contributes no hashes — but if that ever changes, the CSP is
+ * derived from the final file and stays correct by construction.
+ */
+
+import {
+  HERO_HEADLINE_LINES,
+  HERO_HEADLINE_ACCENT,
+  HERO_INTRO,
+  HERO_INTRO_EMPHASIS,
+  splitAround,
+} from '../src/data/heroContent.js';
+
+/** Minimal HTML-escape for text interpolated into the shell. */
+const esc = s =>
+  String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+/**
+ * The static hero. Deliberately plain: no Tailwind utilities, because this is
+ * replaced within a frame of the bundle executing and styling it would mean a
+ * second copy of the hero's design to keep in step. The inline styles below
+ * exist only so the pre-paint frame is dark-on-dark rather than a flash of
+ * black serif text on the #060a13 background painted by the shell's <style>.
+ */
+export function renderHeroShell() {
+  const headline = HERO_HEADLINE_LINES.join(' ');
+  const h = splitAround(headline, HERO_HEADLINE_ACCENT);
+  const p = splitAround(HERO_INTRO, HERO_INTRO_EMPHASIS);
+
+  const headlineHtml = h.match
+    ? `${esc(h.before)}<span style="color:#34d399">${esc(h.match)}</span>${esc(h.after)}`
+    : esc(h.before);
+  const introHtml = p.match
+    ? `${esc(p.before)}<strong style="color:#e2e8f0;font-weight:600">${esc(p.match)}</strong>${esc(p.after)}`
+    : esc(p.before);
+
+  return (
+    `<div id="hero-shell" style="max-width:56rem;margin:0 auto;padding:8rem 1.5rem 0;text-align:center;color:#94a3b8;font-family:system-ui,sans-serif">` +
+    `<p style="font-size:.75rem;letter-spacing:.2em;text-transform:uppercase;color:#34d399">Software Engineer · Pondicherry, India</p>` +
+    `<h1 style="margin:1.25rem 0 0;font-size:2.25rem;line-height:1.05;font-weight:700;color:#fff">${headlineHtml}</h1>` +
+    `<p style="margin:1rem auto 0;max-width:42rem;line-height:1.625">${introHtml}</p>` +
+    `</div>`
+  );
+}
+
+export default function prerenderHero() {
+  return {
+    name: 'prerender-hero',
+    apply: 'build',
+    transformIndexHtml: {
+      order: 'pre',
+      handler(html) {
+        const root = '<div id="root"></div>';
+        if (!html.includes(root)) {
+          // Loud rather than silent: a renamed or reformatted root element would
+          // otherwise drop the prerender and leave the shell empty again, with
+          // nothing in CI to notice — the same failure mode this plugin fixes.
+          throw new Error(
+            `[prerender-hero] could not find \`${root}\` in index.html; the hero was not injected.`
+          );
+        }
+        return html.replace(root, `<div id="root">${renderHeroShell()}</div>`);
+      },
+    },
+  };
+}

--- a/src/__tests__/prerenderHero.test.js
+++ b/src/__tests__/prerenderHero.test.js
@@ -14,26 +14,27 @@ import prerenderHero, { renderHeroShell } from '../../scripts/vite-plugin-preren
 import { HERO_HEADLINE_LINES, HERO_INTRO, splitAround } from '../data/heroContent.js';
 
 const runTransform = html => prerenderHero().transformIndexHtml.handler(html);
-const stripTags = s => s.replace(/<[^>]+>/g, '');
-const decode = s =>
-  s
-    .replace(/&quot;/g, '"')
-    .replace(/&gt;/g, '>')
-    .replace(/&lt;/g, '<')
-    .replace(/&amp;/g, '&');
+
+// Read the shell back by parsing it, not by regex. An earlier version stripped
+// tags with `replace(/<[^>]+>/g, '')` and hand-decoded entities; CodeQL flagged
+// that as an incomplete multi-character sanitizer and was right to — `<scr<script>ipt>`
+// survives a single pass. Nothing untrusted reaches it here, but a test asserting
+// on escaping shouldn't itself contain a broken unescaper. Parsing is also simply
+// more accurate: textContent decodes entities for free, and the tag set below is
+// the elements a browser actually builds rather than the ones a regex can spot.
+const parse = html => new DOMParser().parseFromString(html, 'text/html');
+const textOf = html => parse(html).body.textContent;
 
 describe('renderHeroShell', () => {
   it('emits exactly one h1 containing the full headline', () => {
-    const html = renderHeroShell();
-    expect(html.match(/<h1\b/g)).toHaveLength(1);
-
-    const inner = /<h1[^>]*>([\s\S]*?)<\/h1>/.exec(html)[1];
-    expect(decode(stripTags(inner))).toBe(HERO_HEADLINE_LINES.join(' '));
+    const doc = parse(renderHeroShell());
+    const h1s = doc.querySelectorAll('h1');
+    expect(h1s).toHaveLength(1);
+    expect(h1s[0].textContent).toBe(HERO_HEADLINE_LINES.join(' '));
   });
 
   it('emits the intro copy verbatim', () => {
-    const body = decode(stripTags(renderHeroShell()));
-    expect(body).toContain(HERO_INTRO);
+    expect(textOf(renderHeroShell())).toContain(HERO_INTRO);
   });
 
   it('ships nothing hidden — no opacity:0 or display:none', () => {
@@ -52,11 +53,11 @@ describe('renderHeroShell', () => {
 
   it('escapes text rather than interpolating it raw', () => {
     // Guard against the copy ever containing a character that would break out
-    // of the markup. Only tags this function itself emits should be present.
-    const emitted = renderHeroShell()
-      .match(/<\/?([a-z0-9]+)/gi)
-      .map(t => t.replace(/<\/?/, ''));
-    expect(new Set(emitted)).toEqual(new Set(['div', 'p', 'h1', 'span', 'strong']));
+    // of the markup. Only elements this function itself emits should exist —
+    // asked of the parsed tree, so it's the elements a browser really builds.
+    const doc = parse(renderHeroShell());
+    const built = new Set([...doc.body.querySelectorAll('*')].map(el => el.tagName.toLowerCase()));
+    expect(built).toEqual(new Set(['div', 'p', 'h1', 'span', 'strong']));
   });
 });
 

--- a/src/__tests__/prerenderHero.test.js
+++ b/src/__tests__/prerenderHero.test.js
@@ -9,9 +9,17 @@
 
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
 import prerenderHero, { renderHeroShell } from '../../scripts/vite-plugin-prerender-hero.js';
 import { HERO_HEADLINE_LINES, HERO_INTRO, splitAround } from '../data/heroContent.js';
+
+// Vite's transform does define __dirname here, so the earlier version worked —
+// but it only works under a bundler. Deriving the path from import.meta.url is
+// what plain ESM gives us, and it matches assetsignore.test.js, the other test
+// that reads repo files off disk.
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const read = relative => readFileSync(resolve(repoRoot, relative), 'utf8');
 
 const runTransform = html => prerenderHero().transformIndexHtml.handler(html);
 
@@ -74,14 +82,13 @@ describe('the plugin', () => {
 
   it('matches the real index.html, so the build cannot quietly stop injecting', () => {
     // The throw above only helps if the pattern still matches the real file.
-    const html = readFileSync(resolve(__dirname, '../../index.html'), 'utf8');
-    expect(() => runTransform(html)).not.toThrow();
+    expect(() => runTransform(read('index.html'))).not.toThrow();
   });
 });
 
 describe('single source of copy', () => {
   it('HeroSection contains no hardcoded headline or intro text', () => {
-    const src = readFileSync(resolve(__dirname, '../components/sections/HeroSection.jsx'), 'utf8');
+    const src = read('src/components/sections/HeroSection.jsx');
     // Both renderers must read heroContent.js. If someone re-types the sentence
     // into the JSX, the two copies can drift and only one of them is indexed.
     const code = src.replace(/\{\/\*[\s\S]*?\*\/\}/g, ''); // drop JSX comments

--- a/src/__tests__/prerenderHero.test.js
+++ b/src/__tests__/prerenderHero.test.js
@@ -1,0 +1,109 @@
+/**
+ * @file prerenderHero.test.js
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Guards the build-time hero prerender: that it produces a real
+ *   <h1>, that its words come from the same module HeroSection renders, and
+ *   that it fails loudly rather than silently if the shell changes shape.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import prerenderHero, { renderHeroShell } from '../../scripts/vite-plugin-prerender-hero.js';
+import { HERO_HEADLINE_LINES, HERO_INTRO, splitAround } from '../data/heroContent.js';
+
+const runTransform = html => prerenderHero().transformIndexHtml.handler(html);
+const stripTags = s => s.replace(/<[^>]+>/g, '');
+const decode = s =>
+  s
+    .replace(/&quot;/g, '"')
+    .replace(/&gt;/g, '>')
+    .replace(/&lt;/g, '<')
+    .replace(/&amp;/g, '&');
+
+describe('renderHeroShell', () => {
+  it('emits exactly one h1 containing the full headline', () => {
+    const html = renderHeroShell();
+    expect(html.match(/<h1\b/g)).toHaveLength(1);
+
+    const inner = /<h1[^>]*>([\s\S]*?)<\/h1>/.exec(html)[1];
+    expect(decode(stripTags(inner))).toBe(HERO_HEADLINE_LINES.join(' '));
+  });
+
+  it('emits the intro copy verbatim', () => {
+    const body = decode(stripTags(renderHeroShell()));
+    expect(body).toContain(HERO_INTRO);
+  });
+
+  it('ships nothing hidden — no opacity:0 or display:none', () => {
+    // The reason this prerender writes its own markup instead of using
+    // renderToStaticMarkup on the real component: that path serialises motion's
+    // initial state, which is opacity:0 on ten elements.
+    expect(renderHeroShell()).not.toMatch(/opacity\s*:\s*0\b/);
+    expect(renderHeroShell()).not.toMatch(/display\s*:\s*none/);
+  });
+
+  it('adds no inline script or event handler, so the CSP hash set is unchanged', () => {
+    const html = renderHeroShell();
+    expect(html).not.toMatch(/<script/i);
+    expect(html).not.toMatch(/\son[a-z]+\s*=/i);
+  });
+
+  it('escapes text rather than interpolating it raw', () => {
+    // Guard against the copy ever containing a character that would break out
+    // of the markup. Only tags this function itself emits should be present.
+    const emitted = renderHeroShell()
+      .match(/<\/?([a-z0-9]+)/gi)
+      .map(t => t.replace(/<\/?/, ''));
+    expect(new Set(emitted)).toEqual(new Set(['div', 'p', 'h1', 'span', 'strong']));
+  });
+});
+
+describe('the plugin', () => {
+  it('injects the hero into an empty #root', () => {
+    const out = runTransform('<body><div id="root"></div></body>');
+    expect(out).toMatch(/<div id="root"><div id="hero-shell"/);
+    expect(out).toContain('</h1>');
+  });
+
+  it('throws if #root is not found, rather than silently shipping an empty shell', () => {
+    expect(() => runTransform('<body><div id="app"></div></body>')).toThrow(/could not find/i);
+  });
+
+  it('matches the real index.html, so the build cannot quietly stop injecting', () => {
+    // The throw above only helps if the pattern still matches the real file.
+    const html = readFileSync(resolve(__dirname, '../../index.html'), 'utf8');
+    expect(() => runTransform(html)).not.toThrow();
+  });
+});
+
+describe('single source of copy', () => {
+  it('HeroSection contains no hardcoded headline or intro text', () => {
+    const src = readFileSync(resolve(__dirname, '../components/sections/HeroSection.jsx'), 'utf8');
+    // Both renderers must read heroContent.js. If someone re-types the sentence
+    // into the JSX, the two copies can drift and only one of them is indexed.
+    const code = src.replace(/\{\/\*[\s\S]*?\*\/\}/g, ''); // drop JSX comments
+    for (const line of HERO_HEADLINE_LINES) {
+      expect(code, `"${line}" is hardcoded in HeroSection`).not.toContain(line);
+    }
+    expect(code).not.toContain(HERO_INTRO.slice(0, 40));
+    expect(src).toContain("from '../../data/heroContent.js'");
+  });
+});
+
+describe('splitAround', () => {
+  it('splits around the word', () => {
+    expect(splitAround('go faster.', 'faster')).toEqual({
+      before: 'go ',
+      match: 'faster',
+      after: '.',
+    });
+  });
+
+  it('returns the whole string when the word is absent, dropping no copy', () => {
+    const r = splitAround('no match here', 'zzz');
+    expect(r).toEqual({ before: 'no match here', match: '', after: '' });
+    expect(r.before + r.match + r.after).toBe('no match here');
+  });
+});

--- a/src/components/sections/HeroSection.jsx
+++ b/src/components/sections/HeroSection.jsx
@@ -15,6 +15,20 @@ import { useExperienceCalculator, useThrottledScroll, useRipple, useCountUp } fr
 import { AnimatedMeshGradient } from '../background';
 import { buttonMotion } from '../../utils/microInteractions';
 import { RESUME_URL } from '../../data/links.js';
+import {
+  HERO_HEADLINE_LINES,
+  HERO_HEADLINE_ACCENT,
+  HERO_INTRO,
+  HERO_INTRO_EMPHASIS,
+  splitAround,
+} from '../../data/heroContent.js';
+
+// The headline and intro are read from data rather than written out here,
+// because the build-time prerender in scripts/vite-plugin-prerender-hero.js
+// puts the same words into the static shell's <h1>. Two hand-written copies of
+// one sentence is the drift this repo keeps having to undo.
+const HEADLINE = HERO_HEADLINE_LINES.map(line => splitAround(line, HERO_HEADLINE_ACCENT));
+const INTRO = splitAround(HERO_INTRO, HERO_INTRO_EMPHASIS);
 
 // One stat cell. Split into its own component so each can own a useCountUp
 // call (hooks can't run inside the parent's .map). `start` flips true when the
@@ -119,29 +133,30 @@ const HeroSection = React.memo(function HeroSection() {
             <span className='eyebrow text-brand-300'>Software Engineer · Pondicherry, India</span>
           </motion.div>
 
-          {/* Headline */}
-          <motion.h1
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.1 }}
-            className='text-balance text-4xl font-bold leading-[1.05] sm:text-6xl lg:text-7xl'
-          >
-            I make AI accelerators
-            <br />
-            go <span className='gradient-text-shimmer'>faster</span>.
-          </motion.h1>
+          {/* Headline. No entrance animation, unlike everything around it: these
+              two elements are already on screen before React runs, written into
+              the static shell by scripts/vite-plugin-prerender-hero.js. Fading
+              them in from opacity 0 made the headline visibly vanish and
+              reappear at mount — measured at 645ms of flicker, which is worse
+              than the animation was ever worth. The elements below this are not
+              prerendered, so they still animate and the hero still assembles. */}
+          <h1 className='text-balance text-4xl font-bold leading-[1.05] sm:text-6xl lg:text-7xl'>
+            {HEADLINE.map((line, i) => (
+              <React.Fragment key={i}>
+                {i > 0 && <br />}
+                {line.before}
+                {line.match && <span className='gradient-text-shimmer'>{line.match}</span>}
+                {line.after}
+              </React.Fragment>
+            ))}
+          </h1>
 
-          {/* Sub copy */}
-          <motion.p
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.2 }}
-            className='mx-auto mt-4 max-w-2xl text-pretty text-sm leading-relaxed text-slate-400 sm:mt-5 sm:text-lg'
-          >
-            I&apos;m <span className='font-semibold text-slate-200'>Aswin</span> — I profile,
-            benchmark, and optimize the software that runs on next-generation AI silicon at
-            MulticoreWare. Off the clock, I run my own cloud.
-          </motion.p>
+          {/* Sub copy — prerendered too, so likewise unanimated. */}
+          <p className='mx-auto mt-4 max-w-2xl text-pretty text-sm leading-relaxed text-slate-400 sm:mt-5 sm:text-lg'>
+            {INTRO.before}
+            {INTRO.match && <span className='font-semibold text-slate-200'>{INTRO.match}</span>}
+            {INTRO.after}
+          </p>
 
           {/* CTAs */}
           <motion.div

--- a/src/data/heroContent.js
+++ b/src/data/heroContent.js
@@ -1,0 +1,50 @@
+/**
+ * @file heroContent.js
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description The hero headline and intro, as plain strings.
+ *
+ *   Two things render this copy: HeroSection, and the build-time prerender that
+ *   writes an <h1> into the static shell (scripts/vite-plugin-prerender-hero.js)
+ *   so the page's first meaningful content is in the HTML rather than only in
+ *   the bundle. They must say the same thing, and the cheap way to get that —
+ *   writing the sentences out in both places — is the drift we keep paying for
+ *   elsewhere in this repo. So the words live here once and both read them.
+ *
+ *   Keep this module free of JSX: the Vite plugin imports it directly in Node,
+ *   which has no JSX loader. Emphasis is expressed as a substring to wrap, not
+ *   as markup, for the same reason.
+ */
+
+/**
+ * The headline, one string per visual line. HeroSection joins them with <br>;
+ * the prerender joins them with a space, since the static copy has no width to
+ * break against.
+ */
+export const HERO_HEADLINE_LINES = ['I make AI accelerators', 'go faster.'];
+
+/** The word in the headline carrying the shimmer gradient. */
+export const HERO_HEADLINE_ACCENT = 'faster';
+
+export const HERO_INTRO =
+  "I'm Aswin — I profile, benchmark, and optimize the software that runs on " +
+  'next-generation AI silicon at MulticoreWare. Off the clock, I run my own cloud.';
+
+/** The word in the intro rendered at a brighter weight. */
+export const HERO_INTRO_EMPHASIS = 'Aswin';
+
+/**
+ * Splits `text` into the part before `word`, the word, and the part after, so a
+ * caller can wrap the middle in whatever element it likes. Returns the whole
+ * string as `before` when the word isn't found, which degrades to unstyled text
+ * rather than dropping copy.
+ *
+ * @param {string} text
+ * @param {string} word
+ * @returns {{before: string, match: string, after: string}}
+ */
+export const splitAround = (text, word) => {
+  const at = text.indexOf(word);
+  if (at === -1) return { before: text, match: '', after: '' };
+  return { before: text.slice(0, at), match: word, after: text.slice(at + word.length) };
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,9 +1,12 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import securityHeaders from './scripts/vite-plugin-security-headers.js';
+import prerenderHero from './scripts/vite-plugin-prerender-hero.js';
 
 export default defineConfig({
-  plugins: [react(), securityHeaders()],
+  // prerenderHero writes the hero copy into the shell; securityHeaders hashes
+  // the final HTML at closeBundle, so it must stay last.
+  plugins: [react(), prerenderHero(), securityHeaders()],
   server: {
     port: 3000,
     open: true,


### PR DESCRIPTION
## What

The served HTML had no `<h1>`. "I make AI accelerators go faster." was created by React after the bundle parsed, so the shell was `<div id="root"></div>` and nothing else. A build-time Vite plugin now writes the headline and intro into that container.

React's `createRoot()` clears the container before its first render, so the static markup is replaced wholesale on mount. It is never hydrated and never has to match React's output — which is what lets it be much simpler than the real hero.

Lighthouse runs JS, so it scored SEO 100 the whole time. That is exactly what made this easy to miss.

## Why not `renderToStaticMarkup` on the real component

I tried it first. It renders, but HeroSection's entrance animation means motion serialises its initial state — `style="opacity:0"` on **ten elements**. That publishes the headline as invisible text, which is worse than publishing none: it reads as cloaking, and a reader with JS off sees a blank page either way. Stripping the styles back out would leave the build depending on the exact shape of motion's SSR output.

So the plugin emits its own small static markup, and both renderers read the words from `src/data/heroContent.js`. One copy of the sentences, not two — a unit test fails if they are ever re-typed into the JSX.

## The regression I introduced and fixed

The first working version made the headline paint, vanish, and fade back in. Sampling opacity every 25ms across the load measured **645ms of visible flicker** — React cleared the shell, then animated the same words in from zero.

Those two elements are on screen *before* React runs, so animating their entrance was describing something that hadn't happened. Both are now plain elements; everything below them still animates and the hero still assembles.

## Measured against a preview build

| | Result |
|---|---|
| JS disabled | one visible `h1`, computed opacity 1, 848×38, correct text |
| JS enabled | exactly one `h1` after mount, `#hero-shell` gone |
| Handoff | t+273ms, opacity pinned at 1.00 throughout |
| Shimmer on "faster" | intact (`animationName: textShimmer`); reduced-motion unaffected |
| 390px | no horizontal overflow, before or after mount |
| `dist/_headers` | **byte-identical** — no `<script>`, no inline `on*=`, so no CSP hash can move |
| Lighthouse | **95**/100/100/100, up from 90 — FCP 0.8s → 0.5s, CLS 0, TBT 10ms |

Performance going up is the useful side effect: the perf budget in `lighthouserc.json` had **zero margin** at 90 before this.

## A test this change silently weakened

`smoke.spec.js` proved React had mounted by asserting `#root` has children. The prerender gives it children unconditionally, so that assertion stopped distinguishing "React rendered" from "the bundle never executed." It now waits for `#hero-shell` to **disappear** — the one signal that still means React ran, and it fails closed.

Added alongside: a JS-disabled e2e case (the reader this feature exists for — without it the shell could regress to empty and every other test would still pass, since they all run JS), and 11 unit tests. I verified two of the guards by mutation rather than assuming: re-hardcoding the headline fails the single-source test, and shipping an `opacity:0` headline fails the nothing-hidden test.

## Verification

`npm run lint` · **244** unit tests (was 233) · `copyright:check:strict` · `npm run build` · **21** e2e (was 20) — all pass.
