### PR TITLE
Dynamic hero: twinkling starfield

### DIFF
--- a/src/components/background/StarField.jsx
+++ b/src/components/background/StarField.jsx
@@ -1,0 +1,53 @@
+/**
+ * @file StarField.jsx
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Decorative hero layer: a field of faint stars that twinkle at
+ *   staggered intervals. Pure CSS animation (the existing pulse-slow keyframe),
+ *   so nothing runs per frame; aria-hidden, and it freezes under the global
+ *   prefers-reduced-motion block.
+ */
+
+import React from 'react';
+
+// Deterministic scatter via a tiny seeded PRNG: the field is identical on every
+// mount and there is no Math.random in render. Placement quality only needs to
+// look unstructured, which this comfortably clears.
+const seeded = (() => {
+  let s = 0x9e3779b9;
+  return () => {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+})();
+
+const STARS = Array.from({ length: 46 }, () => ({
+  top: `${(seeded() * 100).toFixed(2)}%`,
+  left: `${(seeded() * 100).toFixed(2)}%`,
+  size: (seeded() * 2 + 1).toFixed(2),
+  delay: `${(seeded() * 3).toFixed(2)}s`,
+  opacity: (seeded() * 0.5 + 0.15).toFixed(2),
+}));
+
+const StarField = () => (
+  <div aria-hidden='true' className='pointer-events-none absolute inset-0 overflow-hidden'>
+    {STARS.map((star, i) => (
+      <span
+        key={i}
+        className='absolute rounded-full bg-brand-200 animate-pulse-slow'
+        style={{
+          top: star.top,
+          left: star.left,
+          width: `${star.size}px`,
+          height: `${star.size}px`,
+          opacity: star.opacity,
+          animationDelay: star.delay,
+        }}
+      />
+    ))}
+  </div>
+);
+
+export default StarField;

--- a/src/components/sections/HeroSection.jsx
+++ b/src/components/sections/HeroSection.jsx
@@ -13,6 +13,7 @@ import { Mail, ArrowRight, FileText, ArrowDown, MessageCircle } from 'lucide-rea
 import { Github, Linkedin } from '../icons/BrandIcons.jsx';
 import { useExperienceCalculator, useThrottledScroll, useRipple, useCountUp } from '../../hooks';
 import { AnimatedMeshGradient } from '../background';
+import StarField from '../background/StarField.jsx';
 import { buttonMotion } from '../../utils/microInteractions';
 import { RESUME_URL } from '../../data/links.js';
 import {
@@ -101,6 +102,7 @@ const HeroSection = React.memo(function HeroSection() {
   return (
     <section id='home' className='relative flex min-h-dvh flex-col overflow-hidden'>
       <AnimatedMeshGradient />
+      <StarField />
 
       {/* Content is centered in the space below the fixed nav. `my-auto`
           (rather than justify-center) centers when there's room but lets the


### PR DESCRIPTION
## Dynamic hero — Option 2: Twinkling starfield

Adds a field of faint stars that twinkle at staggered intervals behind the headline, giving the dark backdrop subtle life.

**What's in it**
- New `src/components/background/StarField.jsx` — 46 stars placed by a tiny seeded PRNG (deterministic, identical every mount, no `Math.random` in render), twinkling via the existing `pulse-slow` keyframe.
- One line wired into `HeroSection` after the aurora backdrop.

**Notes**
- Pure CSS animation — nothing runs per frame (in keeping with this repo's no-rAF stance).
- `aria-hidden`, `pointer-events-none`; freezes under `prefers-reduced-motion`.
- No new dependencies.

_One of several independent "make the hero more dynamic" options — each on its own branch so you can compare and merge just the one you like._
