### PR TITLE
Dynamic hero: typewriter rotating role line

### DIFF
--- a/src/components/RotatingRoles.jsx
+++ b/src/components/RotatingRoles.jsx
@@ -1,0 +1,76 @@
+/**
+ * @file RotatingRoles.jsx
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description The hero role line, animated: it types out a short rotation of
+ *   roles with a blinking caret, then erases and moves to the next. Driven by
+ *   chained timeouts (nothing runs per frame), and it rests on the first role
+ *   under reduced motion so the line is still meaningful without movement.
+ */
+
+import React, { useEffect, useState } from 'react';
+
+const ROLES = [
+  'Software Engineer',
+  'AI Accelerator Optimizer',
+  'Performance Engineer',
+  'Self-Hosting Enthusiast',
+];
+
+const TYPE_MS = 65;
+const ERASE_MS = 35;
+const HOLD_MS = 1700;
+
+const RotatingRoles = () => {
+  const [text, setText] = useState(ROLES[0]);
+
+  useEffect(() => {
+    const reduce = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+    if (reduce) return undefined;
+
+    let timer;
+    let role = 0;
+    let char = ROLES[0].length;
+    let erasing = false;
+
+    const step = () => {
+      const full = ROLES[role];
+      if (!erasing) {
+        char += 1;
+        setText(full.slice(0, char));
+        if (char >= full.length) {
+          erasing = true;
+          timer = setTimeout(step, HOLD_MS);
+          return;
+        }
+        timer = setTimeout(step, TYPE_MS);
+      } else {
+        char -= 1;
+        setText(full.slice(0, Math.max(char, 0)));
+        if (char <= 0) {
+          erasing = false;
+          role = (role + 1) % ROLES.length;
+          char = 0;
+        }
+        timer = setTimeout(step, ERASE_MS);
+      }
+    };
+
+    // First role is already fully shown on mount; hold, then start erasing.
+    timer = setTimeout(step, HOLD_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <span className='eyebrow text-brand-300'>
+      <span aria-live='polite'>{text}</span>
+      <span
+        aria-hidden='true'
+        className='ml-1 inline-block h-[1em] w-[2px] translate-y-[2px] bg-brand-300 animate-pulse-slow'
+      />
+      <span className='text-slate-500'>· Pondicherry, India</span>
+    </span>
+  );
+};
+
+export default RotatingRoles;

--- a/src/components/sections/HeroSection.jsx
+++ b/src/components/sections/HeroSection.jsx
@@ -13,6 +13,7 @@ import { Mail, ArrowRight, FileText, ArrowDown, MessageCircle } from 'lucide-rea
 import { Github, Linkedin } from '../icons/BrandIcons.jsx';
 import { useExperienceCalculator, useThrottledScroll, useRipple, useCountUp } from '../../hooks';
 import { AnimatedMeshGradient } from '../background';
+import RotatingRoles from '../RotatingRoles.jsx';
 import { buttonMotion } from '../../utils/microInteractions';
 import { RESUME_URL } from '../../data/links.js';
 import {
@@ -130,7 +131,7 @@ const HeroSection = React.memo(function HeroSection() {
 
             {/* text-brand-300 explicitly: `eyebrow` carries no colour, and this
                 one has no SectionHeader to supply it. */}
-            <span className='eyebrow text-brand-300'>Software Engineer · Pondicherry, India</span>
+            <RotatingRoles />
           </motion.div>
 
           {/* Headline. No entrance animation, unlike everything around it: these


### PR DESCRIPTION
## Dynamic hero — Option 5: Typewriter role line

Turns the static role line ("Software Engineer · Pondicherry, India") into an animated one that types out a rotation of roles with a blinking caret, then erases and moves to the next.

**What's in it**
- New `src/components/RotatingRoles.jsx` — cycles `Software Engineer → AI Accelerator Optimizer → Performance Engineer → Self-Hosting Enthusiast`, driven by chained timeouts (nothing per frame), with a blinking caret and the "· Pondicherry, India" suffix kept static.
- Replaces the single role `<span>` in `HeroSection` with the component.

**Notes**
- Rests on the first role under `prefers-reduced-motion`, so the line is still meaningful without movement.
- First role is fully shown on mount → matches the prerendered/no-JS shell; no layout shift, no impact on the SEO `<h1>`.
- No new dependencies.

_One of several independent "make the hero more dynamic" options — each on its own branch so you can compare and merge just the one you like._
