### PR TITLE
Dynamic hero: scrolling tech marquee ribbon

### DIFF
--- a/src/components/sections/HeroSection.jsx
+++ b/src/components/sections/HeroSection.jsx
@@ -13,6 +13,7 @@ import { Mail, ArrowRight, FileText, ArrowDown, MessageCircle } from 'lucide-rea
 import { Github, Linkedin } from '../icons/BrandIcons.jsx';
 import { useExperienceCalculator, useThrottledScroll, useRipple, useCountUp } from '../../hooks';
 import { AnimatedMeshGradient } from '../background';
+import TechMarquee from './TechMarquee.jsx';
 import { buttonMotion } from '../../utils/microInteractions';
 import { RESUME_URL } from '../../data/links.js';
 import {
@@ -252,6 +253,8 @@ const HeroSection = React.memo(function HeroSection() {
             <StatCell key={stat.label} value={stat.value} label={stat.label} start={statsInView} />
           ))}
         </motion.dl>
+
+        <TechMarquee />
       </div>
 
       {/* Scroll indicator — a flow child pinned to the bottom of the hero

--- a/src/components/sections/TechMarquee.jsx
+++ b/src/components/sections/TechMarquee.jsx
@@ -1,0 +1,56 @@
+/**
+ * @file TechMarquee.jsx
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description A hero ribbon: an infinite marquee of the tools in the stack,
+ *   under the stat strip. Pure CSS translate via the existing marquee keyframe
+ *   (no per-frame JS); it pauses on hover, fades at both edges with a mask, and
+ *   is aria-hidden since it is decorative reinforcement of the Technologies
+ *   section below.
+ */
+
+import React from 'react';
+
+const ITEMS = [
+  'C++',
+  'CUDA',
+  'Python',
+  'React',
+  'Docker',
+  'Kubernetes',
+  'Linux',
+  'PyTorch',
+  'MLIR',
+  'Vite',
+  'Node.js',
+  'Cloudflare',
+];
+
+const TechMarquee = () => (
+  <div
+    aria-hidden='true'
+    className='group relative mx-auto mt-7 w-full max-w-2xl overflow-hidden'
+    style={{
+      maskImage: 'linear-gradient(to right, transparent, black 12%, black 88%, transparent)',
+      WebkitMaskImage: 'linear-gradient(to right, transparent, black 12%, black 88%, transparent)',
+    }}
+  >
+    <div className='flex w-max animate-marquee whitespace-nowrap group-hover:[animation-play-state:paused]'>
+      {[0, 1].map(copy => (
+        <div key={copy} className='flex shrink-0'>
+          {ITEMS.map(tech => (
+            <span
+              key={`${copy}-${tech}`}
+              className='mx-5 font-mono text-sm tracking-wide text-slate-500'
+            >
+              {tech}
+              <span className='ml-5 text-brand-500/40'>/</span>
+            </span>
+          ))}
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+export default TechMarquee;


### PR DESCRIPTION
## Dynamic hero — Option 6: Scrolling tech marquee

Adds an infinite marquee ribbon of the tools in the stack just under the hero stat strip, reinforcing the Technologies section with quiet motion.

**What's in it**
- New `src/components/sections/TechMarquee.jsx` — a seamless two-copy marquee (C++, CUDA, Python, React, Docker, Kubernetes, Linux, PyTorch, MLIR, Vite, Node.js, Cloudflare) using the existing `marquee` keyframe, with edge fade masks and pause-on-hover.
- One line wired into `HeroSection` below the stat strip.

**Notes**
- Pure CSS translate — nothing runs per frame.
- `aria-hidden` (decorative reinforcement of the real Technologies section), `pointer-events` limited to the hover-pause.
- No new dependencies.

_One of several independent "make the hero more dynamic" options — each on its own branch so you can compare and merge just the one you like._
