### PR TITLE
feat(hero): give the backdrop a die map lit by the auroras

### DIFF
--- a/src/__tests__/heroBackdrop.test.jsx
+++ b/src/__tests__/heroBackdrop.test.jsx
@@ -1,0 +1,67 @@
+/**
+ * @file heroBackdrop.test.jsx
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Guards the hero die map, which is four divs of pure CSS and so
+ *   has no behaviour to test — but two specific ways to break silently.
+ *
+ *   The first is paint order. The die map works by painting an opaque grid of
+ *   channels *over* the aurora glows, so light survives only in the tile-shaped
+ *   gaps. Move it above the glows and it covers nothing; the tiles disappear and
+ *   the page still renders, still passes every other test, and simply looks like
+ *   it did before. There is no error to catch, which is exactly why it is pinned
+ *   here.
+ *
+ *   The second is the layer being dropped in a refactor. Same failure mode as
+ *   the prerender plugin's throw: silent, invisible, and only noticed later.
+ */
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import AnimatedMeshGradient from '../components/background/AnimatedMeshGradient';
+
+const backdrop = () => render(<AnimatedMeshGradient />).container.firstChild;
+
+describe('hero die map', () => {
+  it('renders the die map and all three of its layers', () => {
+    const root = backdrop();
+    const map = root.querySelector('.die-map');
+    expect(map, '.die-map is missing from the hero backdrop').toBeTruthy();
+    for (const layer of ['die-grid', 'die-lines', 'die-center-damp']) {
+      expect(map.querySelector(`.${layer}`), `.${layer} is missing`).toBeTruthy();
+    }
+  });
+
+  it('paints the die map after the glows that light it', () => {
+    // The whole effect is paint order — see the file header. Compare document
+    // position rather than array indices so this keeps holding if the layers
+    // are moved into a wrapper or a component of their own.
+    const root = backdrop();
+    const map = root.querySelector('.die-map');
+    const glows = [...root.querySelectorAll('.animate-aurora')];
+    expect(glows.length).toBeGreaterThan(0);
+    for (const glow of glows) {
+      // DOCUMENT_POSITION_* is a bitmask, hence the &.
+      const relation = glow.compareDocumentPosition(map);
+      expect(
+        relation & Node.DOCUMENT_POSITION_FOLLOWING,
+        'die map paints before a glow'
+      ).toBeTruthy();
+    }
+  });
+
+  it('stays decorative — the whole backdrop is hidden from assistive tech', () => {
+    const root = backdrop();
+    expect(root.getAttribute('aria-hidden')).toBe('true');
+    expect(root.textContent).toBe('');
+  });
+
+  it('adds nothing that animates, so the compositor keeps its budget', () => {
+    // Three versions of this layer animated and all three cost frames; the
+    // shipped one reuses the auroras instead. A future edit that reintroduces
+    // an animation here should have to measure it first — see the die-map block
+    // in index.css for the numbers.
+    const map = backdrop().querySelector('.die-map');
+    const classes = [...map.querySelectorAll('*')].flatMap(el => [...el.classList]);
+    expect(classes.filter(c => c.startsWith('animate-'))).toEqual([]);
+  });
+});

--- a/src/components/background/AnimatedMeshGradient.jsx
+++ b/src/components/background/AnimatedMeshGradient.jsx
@@ -17,9 +17,16 @@
  *   index.css for why it has to be, and for the paint-order arrangement that
  *   makes tiles switch on and off rather than slide. That block also records why
  *   the layer paints an opaque grid over the glows instead of masking them: the
- *   mask was measured at 22 fps against 50. Reduced motion is handled per
- *   utility there, not by the global override, which does not freeze animations
- *   the way it looks like it should.
+ *   mask was measured at 22 fps against 50.
+ *
+ *   The die map needs no reduced-motion handling of its own, because nothing in
+ *   it animates — the only moving parts on this backdrop are the three auroras,
+ *   which the global override at index.css:663 already covers. Worth knowing if
+ *   you ever give the die layers an animation: that override sets
+ *   animation-duration to 0.01ms with iteration-count 1, which *completes* an
+ *   animation instantly rather than freezing it, so with no fill-mode the
+ *   element snaps to its un-animated style. cube-shell:567 has to pin an
+ *   explicit rest pose for exactly that reason.
  */
 
 import React from 'react';

--- a/src/components/background/AnimatedMeshGradient.jsx
+++ b/src/components/background/AnimatedMeshGradient.jsx
@@ -2,10 +2,24 @@
  * @file AnimatedMeshGradient.jsx
  * @author Aswin
  * @copyright © 2025 Aswin. All rights reserved.
- * @description Hero backdrop: deep-navy canvas with a dotted grid, three slow
+ * @description Hero backdrop: deep-navy canvas with a die map, three slow
  *   aurora glows (emerald + cyan + indigo), and a radial vignette. Purely
- *   decorative, so it is aria-hidden and its motion collapses under
- *   prefers-reduced-motion via the global CSS override.
+ *   decorative, so the whole thing is aria-hidden.
+ *
+ *   The die map replaced a flat dotted grid. That grid was static, and so was
+ *   the hero with it: two screenshots of the same build at different animation
+ *   phases differed in 3.5% of subpixels at a max delta of 23/255, which is the
+ *   aurora at full swing and nothing else. The floorplan gives the section
+ *   something that is visibly alive without adding an object to an already busy
+ *   first screen.
+ *
+ *   All of the motion here is CSS on the compositor — see the die-map block in
+ *   index.css for why it has to be, and for the paint-order arrangement that
+ *   makes tiles switch on and off rather than slide. That block also records why
+ *   the layer paints an opaque grid over the glows instead of masking them: the
+ *   mask was measured at 22 fps against 50. Reduced motion is handled per
+ *   utility there, not by the global override, which does not freeze animations
+ *   the way it looks like it should.
  */
 
 import React from 'react';
@@ -13,13 +27,14 @@ import React from 'react';
 const AnimatedMeshGradient = () => {
   return (
     <div aria-hidden='true' className='absolute inset-0 overflow-hidden bg-ink'>
-      {/* Dotted engineering grid */}
-      <div className='absolute inset-0 grid-bg opacity-70' />
-
       {/* Aurora glow — emerald. Opacities and drift are tuned so the motion is
           actually perceptible: a large, softly-blurred glow needs a strong
           enough tint and a wide enough travel (see the aurora keyframe) to read
-          as "breathing" rather than sitting still. */}
+          as "breathing" rather than sitting still.
+
+          These three are also the die map's light source — the die layers below
+          paint over them, so where a glow is passing the tiles are lit and
+          everywhere else they are not. That is why they come first. */}
       <div
         className='absolute -top-32 -left-24 h-[42rem] w-[42rem] rounded-full animate-aurora'
         style={{
@@ -47,6 +62,22 @@ const AnimatedMeshGradient = () => {
           animationDelay: '-10s',
         }}
       />
+
+      {/* Die map. Paint order is the whole effect: the auroras above are the
+          light, and this paints an opaque grid of channels over them, so light
+          survives only in the tile-shaped gaps between channels. The grid never
+          moves, so tiles switch on and off in place as a glow drifts past
+          rather than sliding around with it.
+
+          Nothing here animates — deliberately. See the die-map block in
+          index.css: every version that added its own animating layer cost
+          frames, and reusing the glows that were already on screen is what
+          made the effect free. */}
+      <div className='die-map'>
+        <div className='die-grid' />
+        <div className='die-lines' />
+        <div className='die-center-damp' />
+      </div>
 
       {/* Radial vignette to keep edges dark and focus the center */}
       <div

--- a/src/index.css
+++ b/src/index.css
@@ -265,6 +265,145 @@
   background-size: 22px 22px;
 }
 
+/* ---------------------------------------------------------------------------
+   Die map — the hero backdrop.
+
+   A chip floorplan whose tiles light up as activation drifts across it. It
+   replaces a flat dotted grid, against which the hero read as static: two
+   screenshots of that build at different animation phases differed in 3.5% of
+   subpixels at a max delta of 23/255. The aurora *was* moving; there was just
+   nothing on screen with enough structure to show it. Giving the light a
+   lattice to fall on is what makes the same motion legible — measured on the
+   backdrop alone, the grid layer went from 0.00% of subpixels changing to
+   36.08%, without a single new animation.
+
+   How it works. The three aurora glows above it in AnimatedMeshGradient are the
+   light; these layers paint an OPAQUE grid of channels, in the page's own ink
+   colour, on top of them. Light survives only in the square holes between the
+   channels, so tiles appear to switch on and off as a glow drifts past while the
+   lattice itself never moves. The grid is what is static and the light is what
+   moves — swap that round and the tiles slide with the glow, which reads as
+   drifting texture rather than a chip.
+
+   Nothing here animates, and that is the point. Commit f5613cb deleted ~370
+   lines of decorative rAF loops from this repo for hurting scroll performance,
+   and TumblingCube.jsx:8-15 records two more measured passes; anything
+   decorative has to clear that bar. Three versions of this layer did not, all
+   measured at 1400x900 against main's 50 fps while scrolling the hero:
+
+     tile mask + 2 moving glows                    22 fps
+     opaque grid painted over 2 moving glows       30 fps
+     same, glows shrunk to aurora size             40 fps
+     opaque grid over the auroras already there    (this)
+
+   The first version's cost was the mask: with the glows removed it ran at 50,
+   with the mask removed at 23, and with the mask present but the glows static at
+   28 — Chrome renders a masked subtree into an intermediate surface on every
+   composited frame. Painting opaque ink over the glows instead removed that
+   surface and bought 8 fps.
+
+   The rest was the glows themselves. CDP confirmed both were properly
+   composited ("active accelerated transform animation") — they were just far too
+   large: 3080x1980 = 6.1Mpx each, against 745x745 = 0.56Mpx for the biggest
+   aurora, and the fps recovered monotonically as they shrank. But even at aurora
+   size two extra animating layers still cost 11 fps, while main's *three*
+   auroras cost nothing, because they were already on screen and already
+   composited. So the fix was to add no animating layer at all and let the
+   auroras be the activation. The die map is now three static, never-repainted
+   divs; the motion is the drift that the hero already had.
+
+   A pleasant consequence: no mask means no mask-composite: intersect, which
+   Chrome only shipped in 120 while Tailwind v4's baseline is 111.
+   --------------------------------------------------------------------------- */
+
+@utility die-map {
+  /* Tile pitch, and how much of that pitch is tile rather than channel. Both
+     die-grid and die-lines derive from these, so the channels and the hairlines
+     agree by construction instead of by two numbers being kept in step by hand.
+     Channel width is the remainder, step - fill: 5px here, 4px on small screens.
+
+     overflow:hidden is not for the children — they are all inset:0 — but so the
+     repeating gradients cannot paint past a rounded or clipped ancestor. */
+  --die-step: 26px;
+  --die-fill: 21px;
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+
+  @media (width < 48rem) {
+    --die-step: 20px;
+    --die-fill: 16px;
+  }
+}
+
+/* The opaque channel grid. Two repeating gradients of solid ink, so the gaps
+   between them are the tiles. Sits above the glows and below nothing — the
+   aurora and vignette are later siblings of .die-map and still paint on top.
+
+   The colour has to be the exact page background, not a translucent black: at
+   any alpha below 1 the glow shows through the channels too and the tiles stop
+   having edges, which is the whole effect. */
+@utility die-grid {
+  position: absolute;
+  inset: 0;
+  background-image:
+    repeating-linear-gradient(
+      to right,
+      var(--color-ink) 0 calc(var(--die-step) - var(--die-fill)),
+      transparent calc(var(--die-step) - var(--die-fill)) var(--die-step)
+    ),
+    repeating-linear-gradient(
+      to bottom,
+      var(--color-ink) 0 calc(var(--die-step) - var(--die-fill)),
+      transparent calc(var(--die-step) - var(--die-fill)) var(--die-step)
+    );
+}
+
+/* Faint hairlines so the die still reads as a die where no glow is passing.
+   Unlit, it is a floorplan; lit, the tiles it outlines light up.
+
+   These carry the whole effect away from the auroras, which is most of the
+   hero — the first version inherited 0.055 alpha from the dotted grid it
+   replaced and the lattice simply vanished outside the top-left corner. Lit
+   tiles are the accent; these are what makes them tiles rather than a stain. */
+@utility die-lines {
+  position: absolute;
+  inset: 0;
+  background-image:
+    repeating-linear-gradient(
+      to right,
+      rgb(148 163 184 / 0.1) 0 1px,
+      transparent 1px var(--die-step)
+    ),
+    repeating-linear-gradient(
+      to bottom,
+      rgb(148 163 184 / 0.1) 0 1px,
+      transparent 1px var(--die-step)
+    );
+}
+
+/* Hold the centre back. The headline and intro sit in a column through the
+   middle of the hero, and a glow passing behind them raises the local
+   background luminance — which Lighthouse cannot catch, because it computes
+   contrast against the CSS background colour and not against the image that
+   actually rendered. Damping the middle keeps measured contrast where it was
+   and puts the activity around the copy rather than under it.
+
+   Tuned against sampled pixels rather than by eye: behind the headline and
+   intro, at 390px and 1400px, worst-case contrast measures 15.6:1 against white
+   and 11.6:1 against the intro's slate-300. The requirement is 4.5:1, so there
+   is a lot of room to soften this if the centre ever reads as too dead. */
+@utility die-center-damp {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    54% 42% at 50% 46%,
+    rgb(6 10 19 / 0.86) 0%,
+    rgb(6 10 19 / 0.48) 60%,
+    transparent 100%
+  );
+}
+
 /* Section seam: a centre-weighted hairline at the top edge so consecutive
    sections read as deliberately separated panels rather than a hard bg swap.
    Rendered via a pseudo-element so it never affects layout/padding.


### PR DESCRIPTION
The home page read as static, and it measurably was. Two screenshots of the same build at different animation phases differed in 3.5% of subpixels — and measured on its own, the grid layer contributed **0.00%**. The aurora was moving the whole time; there was just nothing on screen with enough structure to show it.

This replaces the flat dotted grid with a chip floorplan and lets the glows that were already there light it. The grid layer now changes **36.08%** of its subpixels — without a single new animation.

## How it works

Paint order is the entire effect. The three auroras paint first, then the die map paints an **opaque** grid of channels — in the page's own ink colour — on top of them. Light survives only in the square holes between channels, so tiles switch on and off in place as a glow drifts past, while the lattice itself never moves.

Swap that order and the tiles slide along with the glow, which reads as drifting texture rather than a chip. That is silent when it breaks: the page still renders and every other test still passes, so `heroBackdrop.test.jsx` pins it explicitly.

The colour has to be exactly the page background. At any alpha below 1 the glow bleeds through the channels too and the tiles stop having edges.

## Nothing here animates, and that is the point

Commit f5613cb deleted ~370 lines of decorative rAF loops from this repo for hurting scroll performance, and `TumblingCube.jsx:8-15` records two more measured passes. Three versions of this layer failed that bar, all measured at 1400x900 against main's 50 fps while scrolling the hero:

| version | fps |
|---|---|
| tile mask + 2 moving glows | 22 |
| opaque grid painted over 2 moving glows | 30 |
| same, glows shrunk to aurora size | 40 |
| **opaque grid over the auroras already there** | **shipped** |

The first version's cost was the mask, not the motion — with the glows removed it ran at 50, with the mask removed at 23, and with the mask present but the glows static at 28. Chrome renders a masked subtree into an intermediate surface on every composited frame.

The rest was the glows themselves. CDP confirmed both *were* properly composited ("active accelerated transform animation") — they were simply far too large: 3080x1980 = 6.1Mpx each against 745x745 = 0.56Mpx for the biggest aurora, and fps recovered monotonically as they shrank. But even at aurora size, two extra animating layers still cost 11 fps, while main's *three* auroras cost nothing, because they were already on screen and already composited.

So the fix was to add no animating layer at all. The die map is three static, never-repainted divs; the motion is the drift the hero already had.

## Measurements

| check | result |
|---|---|
| **frame intervals, scrolling the hero** | p50 16.70ms both; p95 33.40ms both; p99 33.5 branch vs 50.0 main |
| Lighthouse | **95 / 100 / 100 / 100** — FCP 0.5s, LCP 1.5s, CLS 0, TBT 10ms |
| contrast, sampled pixels | 15.6:1 and 11.6:1 behind headline/intro at 390px (need 4.5:1) |
| prerender handoff, 6x CPU throttle | h1 at t+147ms, opacity pinned at 1.00 |
| mount transition vs main | 4.11% of subpixels vs main's 8.19% — smaller, not larger |
| `dist/_headers` | byte-identical to main |
| 390px | no horizontal overflow, all three layers present |

Lighthouse performance holds at 95, so #174's 90 → 95 gain is intact and unspent.

An earlier fps harness was too noisy to trust — main's own run-to-run spread was 12.0 fps against an 8.6 fps delta, because pacing the scroll with `setTimeout(20)` caps the loop at 50fps and measures the timer as much as the page. The numbers above come from driving the scroll inside rAF and reporting the frame-interval distribution.

## Two details worth recording

Painting over instead of masking also drops `mask-composite: intersect`, which Chrome only shipped in 120 while Tailwind v4's baseline is 111.

`die-center-damp` holds the middle back because a glow passing behind the copy raises local background luminance in a way **Lighthouse cannot see** — it computes contrast against the CSS background colour, not the image that actually rendered. Hence sampling real pixels. There is a lot of headroom (15.6:1 against a 4.5:1 requirement) if the centre ever reads as too dead.

All four class names were grepped out of `dist/assets/*.css` as real rules — Tailwind v4 finds classes by scanning source text, and a dropped one is an invisible layer rather than an error (`SkillsSection.jsx:14-17`).

## Scope

Hero only. `grid-bg` is untouched — `ApproachBand.jsx:23` and `NotFound.jsx:29` both still use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)