### PR TITLE
fix(seo): declare twitter card tags with name=, not property=

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,16 +63,20 @@
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="Aswin — Software Engineer" />
 
-    <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content="https://www.aswincloud.com/" />
-    <meta property="twitter:title" content="Aswin — Software Engineer" />
+    <!-- Twitter. These take `name`, not `property` — the two families come from
+         different specs. Open Graph is RDFa, where the attribute is `property`;
+         Twitter cards are plain HTML metadata, where it is `name`. Twitter's own
+         crawler happens to accept either, but other consumers that read
+         twitter:* tags don't all have that fallback. -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:url" content="https://www.aswincloud.com/" />
+    <meta name="twitter:title" content="Aswin — Software Engineer" />
     <meta
-      property="twitter:description"
+      name="twitter:description"
       content="Optimizing the software that runs on AI accelerator hardware — profiling, benchmarking, and throughput. Based in Pondicherry, India."
     />
-    <meta property="twitter:image" content="https://www.aswincloud.com/og-image.png" />
-    <meta property="twitter:image:alt" content="Aswin — Software Engineer" />
+    <meta name="twitter:image" content="https://www.aswincloud.com/og-image.png" />
+    <meta name="twitter:image:alt" content="Aswin — Software Engineer" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/__tests__/socialMeta.test.js
+++ b/src/__tests__/socialMeta.test.js
@@ -1,0 +1,58 @@
+/**
+ * @file socialMeta.test.js
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Guards the attribute family of the social-preview meta tags.
+ *
+ * Open Graph and Twitter cards look interchangeable but come from different
+ * specs: og:* is RDFa and takes `property`, twitter:* is plain HTML metadata
+ * and takes `name`. Getting it backwards produces no error anywhere — not in
+ * the build, not in the browser, not in the linter. The tags are simply ignored
+ * by consumers that don't implement the other spec's fallback, and the only
+ * symptom is a link preview that quietly renders without an image.
+ *
+ * All six twitter:* tags shipped with `property` for exactly that reason:
+ * nothing was in a position to complain.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const html = readFileSync(resolve(repoRoot, 'index.html'), 'utf8');
+const head = new DOMParser().parseFromString(html, 'text/html');
+
+/** Every <meta> whose og:/twitter: key sits on the given attribute. */
+const keysOn = (attr, prefix) =>
+  [...head.querySelectorAll(`meta[${attr}^="${prefix}"]`)].map(m => m.getAttribute(attr));
+
+describe('social preview meta tags', () => {
+  it('declares Open Graph tags with property=', () => {
+    expect(keysOn('property', 'og:')).toContain('og:image');
+    expect(keysOn('name', 'og:')).toEqual([]);
+  });
+
+  it('declares Twitter card tags with name=', () => {
+    expect(keysOn('name', 'twitter:')).toEqual(
+      expect.arrayContaining([
+        'twitter:card',
+        'twitter:url',
+        'twitter:title',
+        'twitter:description',
+        'twitter:image',
+        'twitter:image:alt',
+      ])
+    );
+    expect(keysOn('property', 'twitter:')).toEqual([]);
+  });
+
+  it('points both card images at the same absolute URL', () => {
+    // Relative paths resolve against the crawler, not the page, so a preview
+    // image has to be absolute. Both specs need their own copy of it.
+    const og = head.querySelector('meta[property="og:image"]')?.getAttribute('content');
+    const twitter = head.querySelector('meta[name="twitter:image"]')?.getAttribute('content');
+    expect(og).toMatch(/^https:\/\//);
+    expect(twitter).toBe(og);
+  });
+});


### PR DESCRIPTION
## What

All six `twitter:*` meta tags in `index.html` used `property=`. They take `name=`.

```diff
-<meta property="twitter:card" content="summary_large_image" />
+<meta name="twitter:card" content="summary_large_image" />
```

The two tag families look interchangeable, but come from different specs. Open Graph is RDFa, where the attribute genuinely is `property`. Twitter cards are plain HTML metadata, where it's `name`. Sitting next to each other in the same `<head>`, copying the wrong one across is easy — hence the comment now explaining the distinction in place.

## Why it survived this long

The failure mode is silence. No build error, no browser warning, no linter complaint. A consumer that doesn't implement the other spec's fallback just skips the tags, and the only symptom is a link preview rendering without an image.

Twitter's own crawler accepts either attribute — which is the reason this went unnoticed. The one consumer you'd most likely test against is also the one that papers over the bug.

## Test

`src/__tests__/socialMeta.test.js` parses `index.html` and pins the attribute family for both groups — `og:*` on `property`, `twitter:*` on `name`, and *neither* appearing on the other attribute. Plus a third assertion that the two card images agree on one absolute URL, since a relative path resolves against the crawler rather than the page.

Mutation-tested: flipping any single twitter tag back to `property` fails the test and names the tag.

## Verification

- `npm run test:run` → **251 passed** (13 files, +3)
- `npm run lint` clean
- `npm run build`, then grepped `dist/index.html`: **6** `name="twitter:` tags, **0** `property="twitter:`. Worth checking rather than assuming — the prerender plugin rewrites this file at build time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)