### PR TITLE
content: senior software engineer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,8 @@ public/_redirects
 # Playwright
 test-results/
 playwright-report/
+# Lighthouse CI reports, written by `npx @lhci/cli autorun` when running the
+# gate locally. CI never sees these (its lighthouse job is a fresh checkout,
+# separate from the one running format:check), but locally an unguarded
+# `git add .` would commit a dozen HTML/JSON reports.
+.lighthouseci/

--- a/README.md
+++ b/README.md
@@ -117,4 +117,4 @@ Visit the live portfolio: **[www.aswincloud.com](https://www.aswincloud.com)**
 
 ---
 
-Built with ❤️ by [Aswin](https://github.com/Aswincloud) | Software Engineer at MulticoreWare
+Built with ❤️ by [Aswin](https://github.com/Aswincloud) | Senior Software Engineer at MulticoreWare

--- a/index.html
+++ b/index.html
@@ -4,14 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <title>Aswin — Software Engineer</title>
+    <title>Aswin — Senior Software Engineer</title>
     <meta
       name="description"
-      content="Aswin is a software engineer in Pondicherry, India, optimizing the software that runs on AI accelerator hardware — profiling, benchmarking, and squeezing throughput out of specialized silicon. Also builds fast, modern websites and self-hosted cloud infrastructure."
+      content="Aswin is a senior software engineer in Pondicherry, India, optimizing the software that runs on AI accelerator hardware — profiling, benchmarking, and squeezing throughput out of specialized silicon. Also builds fast, modern websites and self-hosted cloud infrastructure."
     />
     <meta
       name="keywords"
-      content="software engineer, web developer, web design, AI accelerator, profiling, benchmarking, tensor optimization, performance optimization, cloud infrastructure, self-hosting, pondicherry, multicoreware"
+      content="senior software engineer, software engineer, web developer, web design, AI accelerator, profiling, benchmarking, tensor optimization, performance optimization, cloud infrastructure, self-hosting, pondicherry, multicoreware"
     />
     <meta name="author" content="Aswin" />
     <link rel="canonical" href="https://www.aswincloud.com/" />
@@ -22,8 +22,8 @@
         "@context": "https://schema.org",
         "@type": "Person",
         "name": "Aswin",
-        "jobTitle": "Software Engineer",
-        "description": "Software engineer optimizing the software that runs on AI accelerator hardware — profiling, benchmarking, and throughput optimization. Also builds modern websites and self-hosted cloud infrastructure. Based in Pondicherry, India.",
+        "jobTitle": "Senior Software Engineer",
+        "description": "Senior software engineer optimizing the software that runs on AI accelerator hardware — profiling, benchmarking, and throughput optimization. Also builds modern websites and self-hosted cloud infrastructure. Based in Pondicherry, India.",
         "url": "https://www.aswincloud.com",
         "sameAs": ["https://github.com/Aswincloud", "https://www.linkedin.com/in/aswin4122001/"],
         "worksFor": {
@@ -52,7 +52,7 @@
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://www.aswincloud.com/" />
-    <meta property="og:title" content="Aswin — Software Engineer" />
+    <meta property="og:title" content="Aswin — Senior Software Engineer" />
     <meta
       property="og:description"
       content="Optimizing the software that runs on AI accelerator hardware — profiling, benchmarking, and throughput. Based in Pondicherry, India."
@@ -61,7 +61,7 @@
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="Aswin — Software Engineer" />
+    <meta property="og:image:alt" content="Aswin — Senior Software Engineer" />
 
     <!-- Twitter. These take `name`, not `property` — the two families come from
          different specs. Open Graph is RDFa, where the attribute is `property`;
@@ -70,13 +70,13 @@
          twitter:* tags don't all have that fallback. -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:url" content="https://www.aswincloud.com/" />
-    <meta name="twitter:title" content="Aswin — Software Engineer" />
+    <meta name="twitter:title" content="Aswin — Senior Software Engineer" />
     <meta
       name="twitter:description"
       content="Optimizing the software that runs on AI accelerator hardware — profiling, benchmarking, and throughput. Based in Pondicherry, India."
     />
     <meta name="twitter:image" content="https://www.aswincloud.com/og-image.png" />
-    <meta name="twitter:image:alt" content="Aswin — Software Engineer" />
+    <meta name="twitter:image:alt" content="Aswin — Senior Software Engineer" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/scripts/vite-plugin-prerender-hero.js
+++ b/scripts/vite-plugin-prerender-hero.js
@@ -20,7 +20,10 @@
  * back out afterwards would leave the build depending on the exact shape of
  * motion's SSR output. So this emits its own small, static markup, and the
  * words come from src/data/heroContent.js, which HeroSection also reads — there
- * is one copy of the sentences, not two.
+ * is one copy of the sentences, not two. That was true of the headline and
+ * intro but not the role line, which was typed out here and in HeroSection
+ * until a title change had to be made in both; it now comes from the module
+ * with the rest.
  *
  * React's createRoot() clears the container before its first render, so this
  * markup is replaced wholesale on mount. It is never hydrated and never has to
@@ -37,6 +40,7 @@
 import {
   HERO_HEADLINE_LINES,
   HERO_HEADLINE_ACCENT,
+  HERO_EYEBROW,
   HERO_INTRO,
   HERO_INTRO_EMPHASIS,
   splitAround,
@@ -71,7 +75,7 @@ export function renderHeroShell() {
 
   return (
     `<div id="hero-shell" style="max-width:56rem;margin:0 auto;padding:8rem 1.5rem 0;text-align:center;color:#94a3b8;font-family:system-ui,sans-serif">` +
-    `<p style="font-size:.75rem;letter-spacing:.2em;text-transform:uppercase;color:#34d399">Software Engineer · Pondicherry, India</p>` +
+    `<p style="font-size:.75rem;letter-spacing:.2em;text-transform:uppercase;color:#34d399">${esc(HERO_EYEBROW)}</p>` +
     `<h1 style="margin:1.25rem 0 0;font-size:2.25rem;line-height:1.05;font-weight:700;color:#fff">${headlineHtml}</h1>` +
     `<p style="margin:1rem auto 0;max-width:42rem;line-height:1.625">${introHtml}</p>` +
     `</div>`

--- a/src/__tests__/prerenderHero.test.js
+++ b/src/__tests__/prerenderHero.test.js
@@ -12,7 +12,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import prerenderHero, { renderHeroShell } from '../../scripts/vite-plugin-prerender-hero.js';
-import { HERO_HEADLINE_LINES, HERO_INTRO, splitAround } from '../data/heroContent.js';
+import { HERO_HEADLINE_LINES, HERO_EYEBROW, HERO_INTRO, splitAround } from '../data/heroContent.js';
 
 // Vite's transform does define __dirname here, so the earlier version worked —
 // but it only works under a bundler. Deriving the path from import.meta.url is
@@ -43,6 +43,14 @@ describe('renderHeroShell', () => {
 
   it('emits the intro copy verbatim', () => {
     expect(textOf(renderHeroShell())).toContain(HERO_INTRO);
+  });
+
+  it('emits the role line verbatim', () => {
+    // The prerendered eyebrow and HeroSection's were separate hardcoded strings
+    // until a job-title change had to be applied to both. Now both read
+    // HERO_EYEBROW, and the pair of assertions here and in "single source of
+    // copy" below is what keeps them from being re-typed apart.
+    expect(textOf(renderHeroShell())).toContain(HERO_EYEBROW);
   });
 
   it('ships nothing hidden — no opacity:0 or display:none', () => {
@@ -96,7 +104,16 @@ describe('single source of copy', () => {
       expect(code, `"${line}" is hardcoded in HeroSection`).not.toContain(line);
     }
     expect(code).not.toContain(HERO_INTRO.slice(0, 40));
+    expect(code, 'the role line is hardcoded in HeroSection').not.toContain(HERO_EYEBROW);
     expect(src).toContain("from '../../data/heroContent.js'");
+  });
+
+  it('the prerender plugin contains no hardcoded role line either', () => {
+    // The plugin is the other renderer, and it was the one holding the second
+    // copy — so guarding only HeroSection would leave the actual drift open.
+    const src = read('scripts/vite-plugin-prerender-hero.js');
+    const code = src.replace(/\/\*[\s\S]*?\*\//g, ''); // drop block comments
+    expect(code, 'the role line is hardcoded in the prerender plugin').not.toContain(HERO_EYEBROW);
   });
 });
 

--- a/src/components/sections/AboutSection.jsx
+++ b/src/components/sections/AboutSection.jsx
@@ -17,8 +17,8 @@ const PARAGRAPHS = [
   {
     body: (
       <>
-        I&apos;m a <span className='font-semibold text-slate-100'>software engineer</span> based in
-        Pondicherry, working at MulticoreWare on the software that runs on{' '}
+        I&apos;m a <span className='font-semibold text-slate-100'>senior software engineer</span>{' '}
+        based in Pondicherry, working at MulticoreWare on the software that runs on{' '}
         <span className='font-semibold text-slate-100'>AI accelerator hardware</span>. Most days
         that means profiling tensor operations, hunting bottlenecks, and turning benchmark numbers
         into something faster.

--- a/src/components/sections/HeroSection.jsx
+++ b/src/components/sections/HeroSection.jsx
@@ -18,6 +18,7 @@ import { RESUME_URL } from '../../data/links.js';
 import {
   HERO_HEADLINE_LINES,
   HERO_HEADLINE_ACCENT,
+  HERO_EYEBROW,
   HERO_INTRO,
   HERO_INTRO_EMPHASIS,
   splitAround,
@@ -130,7 +131,7 @@ const HeroSection = React.memo(function HeroSection() {
 
             {/* text-brand-300 explicitly: `eyebrow` carries no colour, and this
                 one has no SectionHeader to supply it. */}
-            <span className='eyebrow text-brand-300'>Software Engineer · Pondicherry, India</span>
+            <span className='eyebrow text-brand-300'>{HERO_EYEBROW}</span>
           </motion.div>
 
           {/* Headline. No entrance animation, unlike everything around it: these

--- a/src/data/experienceData.js
+++ b/src/data/experienceData.js
@@ -4,7 +4,7 @@
 export const getExperienceData = experience => [
   {
     period: 'June 2023 - Present',
-    title: 'Software Developer Engineer',
+    title: 'Senior Software Engineer',
     company: 'MulticoreWare Pvt Ltd',
     location: 'Chennai, India',
     logo: '/MulticoreWare_Logo.jpg',

--- a/src/data/heroContent.js
+++ b/src/data/heroContent.js
@@ -26,6 +26,14 @@ export const HERO_HEADLINE_LINES = ['I make AI accelerators', 'go faster.'];
 /** The word in the headline carrying the shimmer gradient. */
 export const HERO_HEADLINE_ACCENT = 'faster';
 
+/**
+ * The role line above the headline. Lives here for the same reason the headline
+ * does: HeroSection and the prerender both render it, and it was previously
+ * typed out in both — the one piece of hero copy this module didn't already
+ * own, and so the one that could drift.
+ */
+export const HERO_EYEBROW = 'Senior Software Engineer · Pondicherry, India';
+
 export const HERO_INTRO =
   "I'm Aswin — I profile, benchmark, and optimize the software that runs on " +
   'next-generation AI silicon at MulticoreWare. Off the clock, I run my own cloud.';


### PR DESCRIPTION
Promotion. The job title was in **14 places across five files**, so this is a sweep rather than a one-line edit.

| File | Spots |
| --- | --- |
| `index.html` | `<title>`, description, keywords, JSON-LD `jobTitle` + `description`, `og:title`, `og:image:alt`, `twitter:title`, `twitter:image:alt` |
| `src/data/experienceData.js` | the MulticoreWare timeline entry — **still one entry**, `June 2023 - Present` unchanged |
| `HeroSection.jsx` + `scripts/vite-plugin-prerender-hero.js` | the role line above the headline |
| `AboutSection.jsx` | body prose |
| `README.md` | footer |

### Two wordings existed before this

The timeline said **"Software Developer Engineer"** while every meta tag and the hero said plain **"Software Engineer"** — they had already drifted. Both are now "Senior Software Engineer".

Two judgment calls worth flagging:

- **Kept plain `software engineer` in the keywords list** alongside the new term. Dropping it would lose a phrase people actually search for, and keywords is a list — it costs nothing to carry both.
- **Left `knowsAbout: "Software Engineering"` alone.** That's a skill in the JSON-LD `knowsAbout` array, not a job title.

### The change exposed a real drift

The role line was the one piece of hero copy `heroContent.js` didn't own — typed out in **both** `HeroSection.jsx` and the prerender plugin. That's exactly what the plugin's own header says the module exists to prevent:

> the words come from src/data/heroContent.js, which HeroSection also reads — there is one copy of the sentences, not two

It was true of the headline and intro, but not the role line. Having to apply this title change to two separate literals is how that surfaced. It now reads `HERO_EYEBROW` from the shared module, and `prerenderHero.test.js` gained two guards:

1. the shell must emit the role line verbatim, and
2. **neither renderer** may contain it as a hardcoded literal — guarding only `HeroSection` would have left the actual drift open, since the plugin held the second copy.

Mutation-tested: re-hardcoding the string in the plugin fails the new test.

```
× the prerender plugin contains no hardcoded role line either
  AssertionError: the role line is hardcoded in the prerender plugin
```

### Also: gitignored `.lighthouseci/`

Now that #186 made the Lighthouse gate real, running it locally leaves 14 HTML/JSON reports in an untracked directory that was in neither `.gitignore` nor `.prettierignore`. An unguarded `git add .` would commit all of them. **CI is unaffected** — its lighthouse job is a separate fresh checkout from the one running `format:check`, so CI never sees the directory. This is a local-only trap, but I hit it while verifying this PR.

### Verification

- **253 unit + 27 e2e green.**
- `dist/index.html` carries the new title in all 7 spots, **none stale** (grepped for the old strings).
- The prerendered eyebrow flows from the shared module into the served HTML — confirmed in `dist`, not just in source.
- JSON-LD still parses; `jobTitle` reads back as "Senior Software Engineer".
- **`dist/_headers` byte-identical** to a pre-change build — text-only edits add no inline script, so no CSP hash moved. Diffed rather than assumed.
- Rendered prose checked in a real browser for spacing artifacts from the `{' '}` Prettier introduced: `"I'm a senior software engineer based in Pondicherry, …"`, no double space.

### One thing to know before merging

Your LinkedIn is in the JSON-LD `sameAs` array, so the structured data will now assert a title your public profile may not show yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)