### PR TITLE
ci(lighthouse): post scores to the PR via the Lighthouse CI GitHub App

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -50,6 +50,27 @@ jobs:
         uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2.1.2
       - name: Run Lighthouse CI
         run: npx --yes @lhci/cli@0.14.x autorun
+        env:
+          # Posts the scores as a status check per URL, so a regression is
+          # readable on the PR instead of only inside this job's log. Purely
+          # additional reporting: the gate that actually fails the build is the
+          # assertMatrix in lighthouserc.cjs, and these contexts are not in
+          # main's required-checks ruleset, so they cannot block the queue.
+          #
+          # With the app token, lhci does not call api.github.com — it POSTs to
+          # Google's hosted relay (githubAppPostStatusCheck), which holds the
+          # app's key and sets the status on our behalf. That is the documented
+          # design; the payload is the scores plus repo slug and commit SHA.
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+          # Without this the status lands on the wrong commit and never appears.
+          # lhci's getCurrentHash() knows Travis, Circle, GitLab and Drone but
+          # not GitHub Actions, so it falls back to
+          # `git rev-list --no-merges -n1 HEAD`. actions/checkout checks out a
+          # *merge* commit on pull_request, and --no-merges then walks to its
+          # first parent — main's tip, not this PR's head. Verified against that
+          # exact topology locally. This override is the first thing the
+          # function checks.
+          LHCI_BUILD_CONTEXT__CURRENT_HASH: ${{ github.event.pull_request.head.sha }}
       - name: Upload Lighthouse reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
         if: always()


### PR DESCRIPTION
`LHCI_GITHUB_APP_TOKEN` was added as an org secret, but nothing referenced it — `pr-checks.yml` passed no secrets at all, so every Lighthouse run logged `⚠️ GitHub token not set` and skipped the status post. This wires it into the Lighthouse step.

## What the token actually does

Exactly one thing, in lhci's `upload.js`: `runGithubStatusCheck` posts the scores as a **commit status per collected URL**, so a regression is readable on the PR instead of only inside the job log.

It is **reporting, not enforcement**. The gate that fails the build is still the `assertMatrix` in `lighthouserc.cjs`.

## Two findings worth recording

**1. `LHCI_BUILD_CONTEXT__CURRENT_HASH` is not optional.** `getCurrentHash()` recognises Travis, Circle, GitLab and Drone — but **not GitHub Actions** — so it falls back to:

```
git rev-list --no-merges -n1 HEAD
```

`actions/checkout` checks out a **merge commit** on `pull_request`, and `--no-merges` then walks to its first parent: **main's tip, not the PR head.** I reproduced that exact topology locally and the hash came back as the base commit — so the status would have been posted to a commit that isn't in this PR, and would never have appeared. The override is the first thing the function checks.

**2. This path does not call `api.github.com`.** With `githubAppToken`, lhci POSTs to Google's hosted relay:

```
https://us-central1-lighthouse-infrastructure.cloudfunctions.net/githubAppPostStatusCheck
```

The relay holds the app's private key and sets the status on our behalf. That's the documented design, and it means no `statuses: write` is needed — the workflow keeps `permissions: contents: read`.

## Blast radius

One status per URL, and we now collect four documents (`/`, `/privacy`, `/terms`, `404.html`). None of those contexts are in main's required-checks ruleset (6505932 requires Lint, Test, Build, Security, Workers Builds), so they're **informational and cannot block the merge queue**.

## Verification

Confirmed the variable name is the one lhci reads rather than assuming it:

| invocation | healthcheck output |
|---|---|
| `lhci healthcheck` | `⚠️  GitHub token not set` |
| `LHCI_GITHUB_APP_TOKEN=… lhci healthcheck` | `✅  GitHub token set` |

That's yargs mapping it to `githubAppToken` via its `LHCI` env prefix. Also confirmed the hash override takes precedence over the `rev-list` fallback, and that the YAML parses with both vars on the right step.

The real proof is this PR: the Lighthouse job should now post per-URL score statuses instead of logging the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)