### PR TITLE
fix(ui): make the menu dismissable and the form enforce what it prints

### DIFF
--- a/e2e/labelInName.spec.js
+++ b/e2e/labelInName.spec.js
@@ -161,7 +161,9 @@ test('the submit button keeps its name in the submitting state', async ({ page }
   // matches the "Visit Email profile" social link further down the section.
   await page.locator('#contact-name').fill('Test');
   await page.locator('#contact-email').fill('test@example.com');
-  await page.locator('#contact-message').fill('Hello');
+  // Has to clear LIMITS.message.min (10) or the form now rejects it client-side
+  // and never reaches the in-flight state this test is about.
+  await page.locator('#contact-message').fill('Hello, this is a test message.');
   await send.click();
 
   const sending = page.getByRole('button', { name: /sending/i });

--- a/e2e/uiAffordances.spec.js
+++ b/e2e/uiAffordances.spec.js
@@ -1,0 +1,75 @@
+/**
+ * @file uiAffordances.spec.js
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description The mobile menu's dismissal affordances, in a real browser at a
+ *   real phone width.
+ *
+ *   These have a jsdom counterpart in src/__tests__/uiAffordances.test.jsx, and
+ *   the duplication is deliberate: the scroll lock is the one assertion jsdom
+ *   cannot make honestly. jsdom has no layout and no scrolling, so it can only
+ *   check that `overflow: hidden` was written to the element — not that the page
+ *   then refuses to move. This file scrolls and reads window.scrollY, which is how
+ *   the bug was found in the first place (the sheet stayed pinned while the page
+ *   ran to y=600 underneath it).
+ */
+
+import { test, expect } from '@playwright/test';
+
+const PHONE = { width: 390, height: 844 };
+
+test.describe('mobile menu dismissal', () => {
+  test.use({ viewport: PHONE });
+
+  test('locks the page behind the open sheet', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: /open menu/i }).click();
+    await expect(page.getByRole('button', { name: /close menu/i })).toBeVisible();
+
+    await page.mouse.wheel(0, 600);
+    // Give the scroll a chance to happen, so a pass means "it didn't" rather
+    // than "we checked too early".
+    await page.waitForTimeout(300);
+
+    expect(await page.evaluate(() => window.scrollY)).toBe(0);
+  });
+
+  test('restores scrolling once dismissed', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: /open menu/i }).click();
+    await expect(page.getByRole('button', { name: /close menu/i })).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('button', { name: /open menu/i })).toBeVisible();
+
+    await page.mouse.wheel(0, 600);
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+  });
+
+  test('Escape and an outside tap both close it', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByRole('button', { name: /open menu/i }).click();
+    await expect(page.getByRole('button', { name: /close menu/i })).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('button', { name: /close menu/i })).toBeHidden();
+
+    await page.getByRole('button', { name: /open menu/i }).click();
+    await expect(page.getByRole('button', { name: /close menu/i })).toBeVisible();
+    // Well below the nav, on the hero.
+    await page.mouse.click(195, 700);
+    await expect(page.getByRole('button', { name: /close menu/i })).toBeHidden();
+  });
+
+  test('a tap on a menu link still navigates rather than being eaten', async ({ page }) => {
+    // The outside-press listener runs on pointerdown, which fires before the
+    // link's click. If the sheet were outside the ref'd <nav>, dismissing would
+    // unmount the link mid-gesture and the navigation would be lost.
+    await page.goto('/');
+    await page.getByRole('button', { name: /open menu/i }).click();
+    await page.getByRole('button', { name: 'Contact' }).click();
+
+    await expect(page.getByRole('button', { name: /close menu/i })).toBeHidden();
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+  });
+});

--- a/src/__tests__/uiAffordances.test.jsx
+++ b/src/__tests__/uiAffordances.test.jsx
@@ -1,0 +1,215 @@
+/**
+ * @file uiAffordances.test.jsx
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Guards the interaction affordances a visitor reaches for without
+ *   thinking, each of which was measured absent in a real browser at 390px before
+ *   this suite existed: dismissing an open overlay with Escape or a press outside
+ *   it, not being able to scroll the page underneath one, a form that enforces the
+ *   rules it prints, and focus landing on the outcome panel after a submit.
+ *
+ *   These are the failures that don't throw. Every one of them leaves a page that
+ *   renders perfectly and behaves wrongly, which is why they survived this long —
+ *   so the tests assert on behaviour (press Escape, is it gone?) rather than on
+ *   the presence of a handler.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import Navigation from '../components/Navigation.jsx';
+import ContactSection from '../components/sections/ContactSection.jsx';
+import { LIMITS } from '../data/contactLimits.js';
+
+// Navigation reads matchMedia through motion and useThrottledScroll; jsdom has no
+// implementation, so give it one that answers "no preference".
+beforeEach(() => {
+  window.matchMedia ??= query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  });
+  document.documentElement.style.overflow = '';
+});
+
+const renderNav = () =>
+  render(
+    <MemoryRouter>
+      <Navigation />
+    </MemoryRouter>
+  );
+
+/** Opens the mobile sheet and returns the toggle. */
+const openMenu = async () => {
+  const toggle = screen.getByRole('button', { name: /open menu/i });
+  fireEvent.click(toggle);
+  await waitFor(() => expect(screen.getByRole('button', { name: /close menu/i })).toBeTruthy());
+  return toggle;
+};
+
+describe('mobile menu dismissal', () => {
+  it('closes on Escape', async () => {
+    renderNav();
+    await openMenu();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: /close menu/i })).toBeNull());
+    expect(screen.getByRole('button', { name: /open menu/i })).toBeTruthy();
+  });
+
+  it('closes on a press outside the nav', async () => {
+    renderNav();
+    await openMenu();
+
+    // pointerdown, not click: the listener uses pointerdown so a press-outside
+    // then drag-back-inside still dismisses.
+    fireEvent.pointerDown(document.body);
+
+    await waitFor(() => expect(screen.queryByRole('button', { name: /close menu/i })).toBeNull());
+  });
+
+  it('does not close on a press inside the nav', async () => {
+    renderNav();
+    await openMenu();
+
+    // The toggle lives inside the ref'd <nav>, which is what stops the very press
+    // that opened the sheet from being read as an outside press.
+    fireEvent.pointerDown(screen.getByRole('button', { name: /close menu/i }));
+
+    expect(screen.getByRole('button', { name: /close menu/i })).toBeTruthy();
+  });
+
+  it('locks page scroll while open and restores it on close', async () => {
+    renderNav();
+    await openMenu();
+
+    expect(document.documentElement.style.overflow).toBe('hidden');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => expect(document.documentElement.style.overflow).toBe(''));
+  });
+
+  it('names the sheet it controls', async () => {
+    renderNav();
+    const toggle = screen.getByRole('button', { name: /open menu/i });
+    // aria-expanded alone says "something expanded" without saying what.
+    expect(toggle.getAttribute('aria-controls')).toBe('mobile-menu');
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.click(toggle);
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /close menu/i }).getAttribute('aria-expanded')
+      ).toBe('true')
+    );
+    expect(document.getElementById('mobile-menu')).toBeTruthy();
+  });
+});
+
+describe('contact form enforces the rules it prints', () => {
+  const fill = ({ name, email, message }) => {
+    fireEvent.change(screen.getByLabelText(/^name$/i), { target: { value: name } });
+    fireEvent.change(screen.getByLabelText(/^email$/i), { target: { value: email } });
+    fireEvent.change(screen.getByLabelText(/^message$/i), { target: { value: message } });
+  };
+
+  it('carries the Worker limits as native constraints', () => {
+    render(<ContactSection />);
+
+    const name = screen.getByLabelText(/^name$/i);
+    const message = screen.getByLabelText(/^message$/i);
+
+    // The panel used to advertise these numbers while the inputs enforced nothing.
+    expect(name.getAttribute('minlength')).toBe(String(LIMITS.name.min));
+    expect(name.getAttribute('maxlength')).toBe(String(LIMITS.name.max));
+    expect(message.getAttribute('minlength')).toBe(String(LIMITS.message.min));
+    expect(message.getAttribute('maxlength')).toBe(String(LIMITS.message.max));
+    expect(screen.getByLabelText(/^email$/i).getAttribute('maxlength')).toBe(
+      String(LIMITS.email.max)
+    );
+  });
+
+  it('rejects a too-short message without a network call', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    render(<ContactSection />);
+
+    fill({ name: 'Ada Lovelace', email: 'ada@example.com', message: 'too short' });
+    fireEvent.submit(screen.getByRole('button', { name: /send message/i }).closest('form'));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy());
+    // The point of the fix: the rule is stated on screen, so applying it should
+    // not cost a round trip.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it('rejects a message that is only whitespace past the minimum', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    render(<ContactSection />);
+
+    // 20 spaces: long enough to pass a naive length check, empty once trimmed —
+    // and the Worker trims before validating.
+    fill({ name: 'Ada Lovelace', email: 'ada@example.com', message: ' '.repeat(20) });
+    fireEvent.submit(screen.getByRole('button', { name: /send message/i }).closest('form'));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy());
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it('derives the printed rules from the shared limits', () => {
+    render(<ContactSection />);
+    // The hint under the textarea quotes the same bounds the input enforces, so
+    // the two cannot drift.
+    expect(
+      screen.getByText(new RegExp(`${LIMITS.message.min}–${LIMITS.message.max} characters`))
+    ).toBeTruthy();
+  });
+
+  it('counts down only near the ceiling, and stays quiet in the middle', () => {
+    render(<ContactSection />);
+    const message = screen.getByLabelText(/^message$/i);
+
+    fireEvent.change(message, { target: { value: 'a'.repeat(200) } });
+    expect(screen.queryByText(/left$/)).toBeNull();
+
+    fireEvent.change(message, { target: { value: 'a'.repeat(LIMITS.message.max - 40) } });
+    expect(screen.getByText('40 left')).toBeTruthy();
+  });
+
+  it('says how much more is needed while below the minimum', () => {
+    render(<ContactSection />);
+    fireEvent.change(screen.getByLabelText(/^message$/i), { target: { value: 'hi' } });
+    expect(screen.getByText(`${LIMITS.message.min - 2} more characters`)).toBeTruthy();
+  });
+
+  it('moves focus to the outcome panel so it cannot be off-screen', async () => {
+    render(<ContactSection />);
+
+    fill({ name: 'Ada Lovelace', email: 'ada@example.com', message: 'nope' });
+    fireEvent.submit(screen.getByRole('button', { name: /send message/i }).closest('form'));
+
+    // role='alert' is announced, but a sighted keyboard visitor got nothing: the
+    // panel renders above the fields, so on a phone it can be off-screen while
+    // you are still looking at the button you pressed.
+    await waitFor(() => expect(document.activeElement).toBe(screen.getByRole('alert')));
+    expect(screen.getByRole('alert').getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('keeps the global focus ring on its fields', () => {
+    render(<ContactSection />);
+    // focus:outline-none here was the only one in the codebase, and it replaced a
+    // 2px outline with a 1px ring at 40% opacity on the controls where keyboard
+    // focus matters most.
+    for (const label of [/^name$/i, /^email$/i, /^message$/i]) {
+      expect(screen.getByLabelText(label).className).not.toContain('focus:outline-none');
+    }
+  });
+});

--- a/src/__tests__/uiAffordances.test.jsx
+++ b/src/__tests__/uiAffordances.test.jsx
@@ -190,6 +190,31 @@ describe('contact form enforces the rules it prints', () => {
     expect(screen.getByText(`${LIMITS.message.min - 2} more characters`)).toBeTruthy();
   });
 
+  it('counts down against the raw length the browser actually caps', () => {
+    render(<ContactSection />);
+    const message = screen.getByLabelText(/^message$/i);
+
+    // 40 real characters short of maxLength, with 30 of them trailing spaces.
+    // Counting trimmed characters here would promise "70 left" on a field that
+    // stops accepting input after 40 — maxLength measures the raw value.
+    const value = 'a'.repeat(LIMITS.message.max - 40) + ' '.repeat(30);
+    fireEvent.change(message, { target: { value } });
+
+    expect(screen.getByText('10 left')).toBeTruthy();
+    expect(screen.queryByText('40 left')).toBeNull();
+  });
+
+  it('never shows a negative count if the value is set past the ceiling', () => {
+    render(<ContactSection />);
+    // maxLength stops typing and pasting, so only a programmatic set reaches here.
+    fireEvent.change(screen.getByLabelText(/^message$/i), {
+      target: { value: 'a'.repeat(LIMITS.message.max + 24) },
+    });
+
+    expect(screen.getByText('24 over the limit')).toBeTruthy();
+    expect(screen.queryByText(/-\d+ left/)).toBeNull();
+  });
+
   it('moves focus to the outcome panel so it cannot be off-screen', async () => {
     render(<ContactSection />);
 

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -9,7 +9,7 @@ import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { motion, AnimatePresence } from 'motion/react';
 import { Menu, X, Terminal } from 'lucide-react';
-import { useThrottledScroll, usePageTransitions } from '../hooks';
+import { useThrottledScroll, usePageTransitions, useDismissable } from '../hooks';
 import { RESUME_URL } from '../data/links.js';
 
 // Performance-optimized Navigation component
@@ -17,6 +17,12 @@ const Navigation = React.memo(function Navigation() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const location = useLocation();
+  // Wraps the bar *and* the sheet, so the toggle counts as "inside" — see the
+  // pointerdown note in useDismissable: a toggle outside this would dismiss on
+  // the same press that opened it.
+  const navRef = React.useRef(null);
+  const closeMenu = React.useCallback(() => setIsMenuOpen(false), []);
+  useDismissable(isMenuOpen, closeMenu, navRef);
 
   const { navigateToSection, currentSection } = usePageTransitions();
   const isHomePage = location.pathname === '/';
@@ -31,8 +37,20 @@ const Navigation = React.memo(function Navigation() {
     (e, href) => {
       if (href.startsWith('#') && isHomePage) {
         e.preventDefault();
-        navigateToSection(href.replace('#', ''));
         setIsMenuOpen(false);
+        // Scroll *after* the sheet closes, not before.
+        //
+        // The open sheet locks the page with `overflow: hidden` on <html>, and a
+        // scrollTo issued while that lock is on is silently discarded — the
+        // element never moves and the lock then lifts, so tapping a menu item did
+        // nothing at all. Caught by the e2e test on the single most common use of
+        // this menu; the unit test could not see it, because jsdom does not
+        // implement scrolling and so cannot refuse one.
+        //
+        // One frame is enough: the setState above commits and React runs the
+        // dismissal effect's cleanup — which restores the overflow — before the
+        // next animation frame. Verified in a real browser rather than inferred.
+        requestAnimationFrame(() => navigateToSection(href.replace('#', '')));
       } else {
         setIsMenuOpen(false);
       }
@@ -55,6 +73,7 @@ const Navigation = React.memo(function Navigation() {
 
   return (
     <nav
+      ref={navRef}
       className={`fixed inset-x-0 top-0 z-50 transition-all duration-300 ${
         scrolled || !isHomePage || isMenuOpen
           ? 'border-b border-hairline bg-ink/80 backdrop-blur-xl'
@@ -127,6 +146,11 @@ const Navigation = React.memo(function Navigation() {
               className='rounded-lg p-2 text-slate-300 transition-colors hover:bg-white/5 hover:text-white md:hidden'
               aria-label={isMenuOpen ? 'Close menu' : 'Open menu'}
               aria-expanded={isMenuOpen}
+              /* aria-expanded on its own says "something is expanded" without
+                 saying what. Naming the sheet lets a screen reader move to the
+                 thing this button controls. The id is static because there is
+                 exactly one nav on the page. */
+              aria-controls='mobile-menu'
             >
               {isMenuOpen ? <X size={22} /> : <Menu size={22} />}
             </button>
@@ -137,6 +161,7 @@ const Navigation = React.memo(function Navigation() {
         <AnimatePresence>
           {isMenuOpen && (
             <motion.div
+              id='mobile-menu'
               initial={{ opacity: 0, height: 0 }}
               animate={{ opacity: 1, height: 'auto' }}
               exit={{ opacity: 0, height: 0 }}

--- a/src/components/ScrollProgress.jsx
+++ b/src/components/ScrollProgress.jsx
@@ -18,16 +18,22 @@ const ScrollProgress = () => {
   // Fade in only after scrolling — avoids a 1px / blur artifact at the top when progress is 0
   const opacity = useTransform(scrollYProgress, [0, 0.02], [0, 1]);
 
+  // aria-hidden on both: these are two decorative gradient bars conveying
+  // something a screen reader already knows better than the DOM can say it —
+  // where you are in the document. Announced, they are noise with no accessible
+  // name, and the glow layer is a second copy of the same nothing.
   return (
     <>
       {/* Top scroll progress bar */}
       <motion.div
+        aria-hidden='true'
         className='pointer-events-none fixed top-0 left-0 right-0 h-0.5 origin-left z-9999 bg-linear-to-r from-brand-400 via-emerald-300 to-cyan-300'
         style={{ scaleX, opacity }}
       />
 
       {/* Glow effect */}
       <motion.div
+        aria-hidden='true'
         className='pointer-events-none fixed top-0 left-0 right-0 h-0.5 origin-left z-9998 bg-linear-to-r from-brand-400/60 via-emerald-300/60 to-cyan-300/60 blur-[3px]'
         style={{ scaleX, opacity }}
       />

--- a/src/components/sections/ContactSection.jsx
+++ b/src/components/sections/ContactSection.jsx
@@ -180,30 +180,48 @@ const ContactSection = () => {
   /**
    * What the counter beside the Message label says.
    *
-   * Counts the trimmed length, because that is the number the Worker checks — a
-   * counter reading 12 on a message that validates as 8 would be actively
-   * misleading at the boundary.
+   * Two different lengths bind at the two ends of the range, so the counter quotes
+   * whichever one the visitor is actually up against rather than picking one and
+   * being wrong at the other end:
    *
-   * Stays quiet in the middle of the range: an untouched field says nothing, a
-   * too-short one says how many more characters are needed, and only the last
-   * 100 characters before the ceiling start counting down. The alternative — a
-   * permanent "413 / 1000" — is a number nobody needs for most of the time it is
-   * on screen, and with aria-live it would also be a stream of announcements.
+   * - The ceiling is the browser's. `maxLength` counts the raw value, whitespace
+   *   included, and stops accepting input there. Counting trimmed characters
+   *   towards it would show "10 left" on a message whose last ten characters are
+   *   trailing spaces — while the keyboard has already gone dead.
+   * - The floor is the Worker's. It trims before measuring, so eight characters
+   *   padded out to twelve still comes back rejected as eight.
+   *
+   * Stays quiet in the middle: an untouched field says nothing, a too-short one
+   * says how many more characters are needed, and only the last 100 before the
+   * ceiling count down. The alternative — a permanent "413 / 1000" — is a number
+   * nobody needs for most of the time it is on screen, and with aria-live it
+   * would also be a stream of announcements.
    */
   const messageCount = React.useMemo(() => {
-    const length = formData.message.trim().length;
-    const tooShort = length > 0 && length < LIMITS.message.min;
-    const remaining = LIMITS.message.max - length;
-    if (tooShort) {
-      const needed = LIMITS.message.min - length;
+    const raw = formData.message.length;
+    const trimmed = formData.message.trim().length;
+    const remaining = LIMITS.message.max - raw;
+
+    // Ceiling first. At maxLength the field has stopped accepting characters, and
+    // telling someone who cannot type "2 more characters" is the worse of the two
+    // messages to show — silently refusing input is the confusion this counter
+    // exists to answer.
+    if (remaining < 0) {
+      // maxLength caps typing and pasting alike, so this is only reachable if the
+      // value is set programmatically. Counting "-24 left" would be the one thing
+      // worse than not saying anything.
+      return { tooShort: false, tooLong: true, label: `${-remaining} over the limit` };
+    }
+    if (remaining <= 100) {
+      return { tooShort: false, tooLong: remaining === 0, label: `${remaining} left` };
+    }
+    if (trimmed > 0 && trimmed < LIMITS.message.min) {
+      const needed = LIMITS.message.min - trimmed;
       return {
-        tooShort,
+        tooShort: true,
         tooLong: false,
         label: `${needed} more character${needed === 1 ? '' : 's'}`,
       };
-    }
-    if (remaining <= 100) {
-      return { tooShort: false, tooLong: remaining <= 0, label: `${remaining} left` };
     }
     return { tooShort: false, tooLong: false, label: '' };
   }, [formData.message]);

--- a/src/components/sections/ContactSection.jsx
+++ b/src/components/sections/ContactSection.jsx
@@ -14,6 +14,7 @@ import SectionHeader from '../SectionHeader.jsx';
 import { sectionAccent } from '../../data/sectionAccents.js';
 import { Mail, MapPin, Briefcase, Send, Check, AlertTriangle, Copy } from 'lucide-react';
 import { useRipple } from '../../hooks';
+import { LIMITS, LIMIT_HINTS } from '../../data/contactLimits.js';
 
 const EMAIL = 'contact@aswincloud.com';
 
@@ -58,6 +59,22 @@ const ContactSection = () => {
   const { createRipple } = useRipple();
   const submitButtonRef = React.useRef(null);
   const [copied, setCopied] = useState(false);
+  const statusRef = React.useRef(null);
+
+  // Move focus to the outcome panel once it appears.
+  //
+  // role='alert' and role='status' make a screen reader announce these, but a
+  // sighted keyboard or mobile visitor got nothing: the panel renders *above* the
+  // fields, so on a phone the reason a submission failed can be off-screen while
+  // you are still looking at the button you pressed. Focusing it both scrolls it
+  // into view and puts the next Tab inside the panel, which is where the mailto
+  // fallback lives on the 'failed' branch.
+  //
+  // tabIndex={-1} on the panel makes it focusable without adding it to the tab
+  // order. preventScroll is deliberately *not* set — the scroll is half the point.
+  React.useEffect(() => {
+    if (submitStatus) statusRef.current?.focus();
+  }, [submitStatus]);
 
   // Click-to-copy for the email card. Prefer the async Clipboard API; fall back
   // to a hidden textarea + execCommand for non-secure contexts / older engines.
@@ -89,7 +106,28 @@ const ContactSection = () => {
       createRipple(e, submitButtonRef.current);
     }
 
-    if (!formData.name || !formData.email || !formData.message) {
+    // Mirror the Worker's own checks (worker.js reads the same LIMITS), and on the
+    // trimmed values, because that is what it validates — otherwise a message of
+    // ten spaces passes here and comes back 400.
+    //
+    // This used to test only for emptiness, so the form accepted input it had just
+    // finished telling the visitor was invalid: a nine-character message made a
+    // round trip to learn a rule stated on screen. The inputs now carry
+    // minLength/maxLength too, which catches it earlier still — this stays as the
+    // backstop for the paths native validation misses (a paste that trims short,
+    // and browsers that skip constraint validation on a scripted submit).
+    const name = formData.name.trim();
+    const email = formData.email.trim();
+    const message = formData.message.trim();
+    const withinLimits =
+      name.length >= LIMITS.name.min &&
+      name.length <= LIMITS.name.max &&
+      email.length > 0 &&
+      email.length <= LIMITS.email.max &&
+      message.length >= LIMITS.message.min &&
+      message.length <= LIMITS.message.max;
+
+    if (!withinLimits) {
       setSubmitStatus('invalid');
       return;
     }
@@ -139,6 +177,37 @@ const ContactSection = () => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 
+  /**
+   * What the counter beside the Message label says.
+   *
+   * Counts the trimmed length, because that is the number the Worker checks — a
+   * counter reading 12 on a message that validates as 8 would be actively
+   * misleading at the boundary.
+   *
+   * Stays quiet in the middle of the range: an untouched field says nothing, a
+   * too-short one says how many more characters are needed, and only the last
+   * 100 characters before the ceiling start counting down. The alternative — a
+   * permanent "413 / 1000" — is a number nobody needs for most of the time it is
+   * on screen, and with aria-live it would also be a stream of announcements.
+   */
+  const messageCount = React.useMemo(() => {
+    const length = formData.message.trim().length;
+    const tooShort = length > 0 && length < LIMITS.message.min;
+    const remaining = LIMITS.message.max - length;
+    if (tooShort) {
+      const needed = LIMITS.message.min - length;
+      return {
+        tooShort,
+        tooLong: false,
+        label: `${needed} more character${needed === 1 ? '' : 's'}`,
+      };
+    }
+    if (remaining <= 100) {
+      return { tooShort: false, tooLong: remaining <= 0, label: `${remaining} left` };
+    }
+    return { tooShort: false, tooLong: false, label: '' };
+  }, [formData.message]);
+
   // Pre-fills the visitor's own mail client with what they already typed, so the fallback
   // costs them a click rather than retyping the message. encodeURIComponent is load-bearing
   // in both fields: an unencoded `&` or `?` in the body would otherwise terminate it and be
@@ -151,8 +220,15 @@ const ContactSection = () => {
     return `mailto:${EMAIL}?subject=${subject}&body=${body}`;
   }, [formData.name, formData.message]);
 
+  // `focus:outline-none` used to be here, replacing index.css's 2px brand-400
+  // outline with a 1px ring at 40% opacity. That was the only outline-none in the
+  // codebase, and it downgraded the focus indicator on the one part of the page
+  // where keyboard focus matters most — a form you fill in field by field. The
+  // border and background shift stay as the on-brand part of the treatment; the
+  // global ring now sits on top of them where it belongs, so these controls look
+  // focused the same way every other control on the site does.
   const fieldClass =
-    'w-full rounded-xl border border-hairline bg-surface-2 px-4 py-3 text-slate-100 placeholder:text-slate-600 transition-colors focus:border-brand-500/60 focus:bg-surface focus:outline-none focus:ring-1 focus:ring-brand-500/40 disabled:opacity-50';
+    'w-full rounded-xl border border-hairline bg-surface-2 px-4 py-3 text-slate-100 placeholder:text-slate-600 transition-colors focus:border-brand-500/60 focus:bg-surface disabled:opacity-50';
 
   return (
     <section
@@ -267,6 +343,8 @@ const ContactSection = () => {
 
               {submitStatus === 'success' && (
                 <div
+                  ref={statusRef}
+                  tabIndex={-1}
                   role='status'
                   className='flex items-start gap-3 rounded-xl border border-brand-500/30 bg-brand-500/10 p-4'
                 >
@@ -283,6 +361,8 @@ const ContactSection = () => {
 
               {submitStatus === 'invalid' && (
                 <div
+                  ref={statusRef}
+                  tabIndex={-1}
                   role='alert'
                   className='flex items-start gap-3 rounded-xl border border-red-500/30 bg-red-500/10 p-4'
                 >
@@ -291,10 +371,14 @@ const ContactSection = () => {
                     <p className='text-sm font-medium text-red-300'>
                       Couldn&apos;t send your message. Please check:
                     </p>
+                    {/* Interpolated from LIMIT_HINTS, not typed out. These bullets
+                        previously hardcoded "2–100" and "10–1000" next to inputs
+                        that enforced neither, which is how the copy came to
+                        describe rules the form did not apply. */}
                     <ul className='mt-1 list-inside list-disc text-sm text-slate-400'>
-                      <li>Name: letters and spaces (2–100 characters)</li>
-                      <li>Email: a valid email address</li>
-                      <li>Message: 10–1000 characters</li>
+                      <li>Name: {LIMIT_HINTS.name}</li>
+                      <li>Email: {LIMIT_HINTS.email}</li>
+                      <li>Message: {LIMIT_HINTS.message}</li>
                     </ul>
                   </div>
                 </div>
@@ -305,6 +389,8 @@ const ContactSection = () => {
                   contents; the mailto carries them across so nothing has to be retyped. */}
               {submitStatus === 'failed' && (
                 <div
+                  ref={statusRef}
+                  tabIndex={-1}
                   role='alert'
                   className='flex items-start gap-3 rounded-xl border border-amber-500/30 bg-amber-500/10 p-4'
                 >
@@ -344,6 +430,8 @@ const ContactSection = () => {
                   placeholder='Your full name'
                   className={fieldClass}
                   required
+                  minLength={LIMITS.name.min}
+                  maxLength={LIMITS.name.max}
                   disabled={isSubmitting}
                   autoComplete='name'
                 />
@@ -365,18 +453,42 @@ const ContactSection = () => {
                   placeholder='you@example.com'
                   className={fieldClass}
                   required
+                  maxLength={LIMITS.email.max}
                   disabled={isSubmitting}
                   autoComplete='email'
                 />
               </div>
 
               <div>
-                <label
-                  htmlFor='contact-message'
-                  className='mb-2 block font-mono text-xs uppercase tracking-wider text-slate-400'
-                >
-                  Message
-                </label>
+                <div className='mb-2 flex items-baseline justify-between gap-3'>
+                  <label
+                    htmlFor='contact-message'
+                    className='block font-mono text-xs uppercase tracking-wider text-slate-400'
+                  >
+                    Message
+                  </label>
+                  {/*
+                    A live count, because maxLength enforces the ceiling silently:
+                    the browser simply stops accepting characters, which reads as a
+                    broken keyboard if you don't know why. This says what the limit
+                    is and how close you are.
+
+                    aria-live='polite' with a coarse update: announcing every
+                    keystroke would make the field unusable with a screen reader, so
+                    the text only changes identity at the two moments that matter —
+                    crossing the minimum, and nearing the ceiling.
+                  */}
+                  <span
+                    aria-live='polite'
+                    className={`font-mono text-xs tabular-nums ${
+                      messageCount.tooLong || messageCount.tooShort
+                        ? 'text-amber-400'
+                        : 'text-slate-600'
+                    }`}
+                  >
+                    {messageCount.label}
+                  </span>
+                </div>
                 <textarea
                   id='contact-message'
                   name='message'
@@ -386,8 +498,14 @@ const ContactSection = () => {
                   rows={5}
                   className={`${fieldClass} resize-none`}
                   required
+                  minLength={LIMITS.message.min}
+                  maxLength={LIMITS.message.max}
+                  aria-describedby='contact-message-hint'
                   disabled={isSubmitting}
                 />
+                <p id='contact-message-hint' className='mt-2 text-xs text-slate-600'>
+                  {LIMIT_HINTS.message}.
+                </p>
               </div>
 
               <motion.button

--- a/src/components/sections/ProjectsSection.jsx
+++ b/src/components/sections/ProjectsSection.jsx
@@ -143,6 +143,31 @@ const ProjectsSection = () => {
     setShowMore(v => !v);
   };
 
+  // Keep the button under the pointer across a collapse.
+  //
+  // Expanding is fine: cards appear below the button and nothing moves under you.
+  // Collapsing removes everything between the button and the viewport top, so the
+  // button jumps upward by the height of the cards that just left — on a phone
+  // that is several screens, and the control you just pressed ends up off-screen
+  // above you with no indication that the list shrank rather than the page broke.
+  //
+  // Runs after the DOM has the new card count, and only on the collapse, so the
+  // expand path stays a pure state change. `block: 'nearest'` scrolls the minimum
+  // needed, which is nothing at all when the button is already in view.
+  //
+  // The mount guard is load-bearing: showMore is already false on the first run,
+  // so without it every visitor would be scrolled down to this button on page
+  // load — the section is most of a screen below the fold, and 'nearest' would
+  // dutifully bring it into view.
+  const hasToggled = useRef(false);
+  React.useEffect(() => {
+    if (!hasToggled.current) {
+      hasToggled.current = true;
+      return;
+    }
+    if (!showMore) btnRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [showMore]);
+
   return (
     <section
       id='projects'

--- a/src/data/contactLimits.js
+++ b/src/data/contactLimits.js
@@ -1,0 +1,53 @@
+/**
+ * @file contactLimits.js
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description The contact form's length rules, shared by the form that enforces
+ *   them and the Worker that rejects violations.
+ *
+ *   These lived only in worker.js, which meant the form could describe rules it
+ *   had no way to apply. It did exactly that: the error panel listed "Name:
+ *   letters and spaces (2–100 characters)" and "Message: 10–1000 characters"
+ *   while the inputs carried nothing but `required`, so a nine-character message
+ *   passed the client check, cost a network round trip, and came back as a red
+ *   box stating a rule the browser could have enforced instantly.
+ *
+ *   Two copies of a number that must agree is the same problem as the two route
+ *   lists in routeMeta.js, and gets the same answer: one list, imported by both
+ *   sides. The form now derives its minlength/maxlength and its visible copy from
+ *   these values, so the advice cannot drift from the enforcement.
+ *
+ *   This module and not worker.js because the Worker is 640 lines of route
+ *   handling and email templates: importing it to reach three numbers would pull
+ *   all of that into the browser bundle. The dependency points the other way —
+ *   worker.js imports this, which is a leaf with no imports of its own.
+ *
+ *   Keep it free of JSX and of any React import, for the same reason as
+ *   routeMeta.js: worker.js loads it in the Workers runtime.
+ */
+
+/**
+ * Field lengths, measured after trimming — which is what the Worker validates,
+ * so the browser has to agree or `   ` would pass one and fail the other.
+ *
+ * `email.max` is the RFC 5321 maximum forward-path length. There is no minimum:
+ * the regex already requires something@something.something.
+ */
+export const LIMITS = {
+  name: { min: 2, max: 100 },
+  message: { min: 10, max: 1000 },
+  email: { max: 254 },
+};
+
+/**
+ * The rule text shown in the form's validation panel.
+ *
+ * Interpolated from LIMITS rather than written out, so editing a bound updates
+ * the advice. The wording stays close to what the Worker's own 400 responses
+ * say, so a visitor who somehow sees both doesn't get two different stories.
+ */
+export const LIMIT_HINTS = {
+  name: `${LIMITS.name.min}–${LIMITS.name.max} characters`,
+  email: 'a valid email address',
+  message: `${LIMITS.message.min}–${LIMITS.message.max} characters`,
+};

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -16,3 +16,4 @@ export { default as usePageTransitions } from './usePageTransitions.js';
 export { useRipple } from './useRipple.jsx';
 export { useCountUp } from './useCountUp.js';
 export { default as useRouteMeta } from './useRouteMeta.js';
+export { useDismissable } from './useDismissable.js';

--- a/src/hooks/useDismissable.js
+++ b/src/hooks/useDismissable.js
@@ -1,0 +1,76 @@
+/**
+ * @file useDismissable.js
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Closes a transient overlay the three ways a visitor expects:
+ *   Escape, a click outside it, and — because it is fixed over the page — by
+ *   locking the scroll underneath while it is open.
+ *
+ *   The mobile nav sheet had none of them. Verified in a real browser at 390px:
+ *   Escape left it open, a click on the page behind left it open, and a scroll
+ *   gesture moved the page to y=600 with the sheet still pinned over the top of
+ *   it. The only way out was finding the toggle again, which is the one control
+ *   the sheet itself can cover.
+ *
+ *   Scroll lock via `overflow: hidden` on <html> rather than <body>: the body is
+ *   what `overflow-x-hidden` and the section backgrounds are set on, and
+ *   overwriting its inline overflow fights those. It also has to restore the
+ *   *previous* value rather than clearing to '', because clearing would drop a
+ *   value some other component set.
+ *
+ *   No focus trap. A trap is the right call for a modal dialog that must not be
+ *   escaped, but this sheet is a nav list in the document flow with the page
+ *   still behind it — trapping focus in it would mean a Tab from the last link
+ *   cycling forever instead of reaching the page, and getting a trap subtly
+ *   wrong is worse than not having one. Escape plus an outside click is what
+ *   this pattern needs.
+ */
+
+import { useEffect } from 'react';
+
+/**
+ * @param {boolean} isOpen - Whether the overlay is currently shown.
+ * @param {() => void} onDismiss - Called on Escape or an outside click. Must be
+ *   stable (useCallback or a setState updater) — it is in the effect's deps, so a
+ *   new identity each render rebinds the listeners.
+ * @param {React.RefObject<HTMLElement>} containerRef - The element that counts as
+ *   "inside". A click within it, or on the toggle if the toggle is inside it, does
+ *   not dismiss.
+ * @param {{ lockScroll?: boolean }} [options] - `lockScroll` freezes the page
+ *   behind the overlay. Defaults to true.
+ */
+export function useDismissable(isOpen, onDismiss, containerRef, { lockScroll = true } = {}) {
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const onKeyDown = event => {
+      if (event.key === 'Escape') onDismiss();
+    };
+
+    // `pointerdown` rather than `click`: a click fires after the pointer is
+    // released, so a visitor who presses outside and drags back in would still
+    // dismiss. pointerdown also beats the React onClick that opened the sheet
+    // to the punch, which is why the toggle has to be inside containerRef —
+    // otherwise opening it would immediately register as an outside press.
+    const onPointerDown = event => {
+      if (!containerRef.current?.contains(event.target)) onDismiss();
+    };
+
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('pointerdown', onPointerDown);
+
+    // Capture what was there so the cleanup restores it instead of clearing to
+    // '' — the latter would discard a value set elsewhere.
+    const root = document.documentElement;
+    const previousOverflow = lockScroll ? root.style.overflow : null;
+    if (lockScroll) root.style.overflow = 'hidden';
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('pointerdown', onPointerDown);
+      if (lockScroll) root.style.overflow = previousOverflow;
+    };
+  }, [isOpen, onDismiss, containerRef, lockScroll]);
+}
+
+export default useDismissable;

--- a/worker.js
+++ b/worker.js
@@ -38,12 +38,14 @@ export const ALLOWED_ORIGIN_PATTERNS = [
   /^http:\/\/127\.0\.0\.1:\d+$/,
 ];
 
-// Contact form limits. Kept here so validation and the tests agree on one source.
-export const LIMITS = {
-  name: { min: 2, max: 100 },
-  message: { min: 10, max: 1000 },
-  email: { max: 254 }, // RFC 5321 maximum forward-path length
-};
+// Contact form limits. These moved to src/data/contactLimits.js so the form can
+// enforce the same numbers this endpoint rejects on: the validation panel used to
+// list "Message: 10–1000 characters" while the textarea carried no maxlength at
+// all, which turned a rule the browser could apply instantly into a round trip.
+// Re-exported here because this module's tests and callers already reach for it
+// at this name, and the endpoint's own validation below reads it.
+export { LIMITS } from './src/data/contactLimits.js';
+import { LIMITS } from './src/data/contactLimits.js';
 
 // Email validation function
 export function isValidEmail(email) {

--- a/worker.js
+++ b/worker.js
@@ -43,9 +43,12 @@ export const ALLOWED_ORIGIN_PATTERNS = [
 // list "Message: 10–1000 characters" while the textarea carried no maxlength at
 // all, which turned a rule the browser could apply instantly into a round trip.
 // Re-exported here because this module's tests and callers already reach for it
-// at this name, and the endpoint's own validation below reads it.
-export { LIMITS } from './src/data/contactLimits.js';
+// at this name, and the endpoint's own validation below reads it. One import, then
+// re-export the binding — naming the same specifier twice would trip
+// no-duplicate-imports if that rule is ever switched on.
 import { LIMITS } from './src/data/contactLimits.js';
+
+export { LIMITS };
 
 // Email validation function
 export function isValidEmail(email) {


### PR DESCRIPTION
Six interaction affordances a visitor reaches for without thinking. Each one was verified absent in a real browser at 390px before being fixed — not inferred from reading the source.

## What was broken

**The mobile menu could only be closed by the toggle it can itself cover.** Measured:

| behavior | before | after |
|---|---|---|
| Escape closes it | ❌ stayed open | ✅ |
| Press outside closes it | ❌ stayed open | ✅ |
| Page scroll locked | ❌ ran to y=600 under the sheet | ✅ stays at 0 |

There were no `keydown` handlers anywhere in `src/`. A new `useDismissable` hook wires up all three, and the toggle now names the sheet it controls with `aria-controls` — `aria-expanded` alone says "something is expanded" without saying what.

**The contact form advertised rules it had no way to apply.** The validation panel listed "Name: 2–100 characters" and "Message: 10–1000 characters" while the inputs carried nothing but `required` — no `minLength`, no `maxLength`, no counter (all verified null in the browser). So a nine-character message passed the client check at `ContactSection.jsx:92`, cost a network round trip, and came back as a red box quoting a rule already on screen.

Those numbers lived only in `worker.js`. They now live in `src/data/contactLimits.js`, which both the Worker and the form import, so the enforcement, the native constraints, and the printed copy are one source and cannot drift. The textarea gains a live counter, because `maxLength` otherwise just stops accepting keystrokes with no explanation — it stays quiet in the middle of the range and speaks only at the two boundaries that matter.

`contactLimits.js` rather than importing `worker.js` directly: the Worker is 640 lines of route handling and email templates, and reaching into it for three numbers would pull all of that into the browser bundle. The dependency points the other way.

**The outcome panels announced themselves to screen readers and to nobody else.** `role='alert'`/`role='status'` are correct, but the panels render *above* the fields — so on a phone the reason a submission failed can be off-screen while you're still looking at the button you pressed. Focus now moves to the panel, which both scrolls it into view and puts the next Tab on the mailto fallback.

**Three smaller ones:** the form's fields were the only place in the codebase using `focus:outline-none`, downgrading `index.css`'s 2px outline to a 1px ring at 40% opacity on the controls where keyboard focus matters most; collapsing the projects list yanked the button several screens up on mobile; and `ScrollProgress` exposed two decorative gradient bars to assistive tech.

## The e2e test earned its place immediately

It caught a regression **this change introduced**: tapping a menu item navigated nowhere. The open sheet's `overflow: hidden` silently discards a `scrollTo` issued underneath it, so the scroll now waits one frame for the lock to lift.

The jsdom suite could not have found that — jsdom doesn't implement scrolling, so it cannot refuse one. That's why the scroll-lock assertion is duplicated across both layers rather than deduplicated.

## Deliberately not changed

Several things I expected to find are already handled, with comments saying so: `MotionConfig reducedMotion='user'` (`App.jsx:237`), the global `*:focus-visible` ring, the skip link, and the footer's `py-1.5`/`w-fit` padding that exists specifically to clear the WCAG 2.5.8 24px floor.

Also checked and **not** flagged: the 32px copy-email button and 40px social icons clear the 24px minimum, and the inline "Stack" link at 21px is explicitly exempt as inline text in a sentence.

## Verification

- **331 unit tests** (13 new), **31 e2e** (4 new), lint, copyright, build — all green
- **Every new test mutation-tested.** Reverting the dismissal hook failed exactly 3; reverting the submit guard failed exactly 2; removing the focus move failed exactly 1; restoring `outline-none` failed exactly 1. No test passes for the wrong reason.
- **Lighthouse accessibility 1.00** on all four URLs; all assertions pass (404.html's SEO 0.63 is the pre-existing `noindex` ceiling the assertMatrix already exempts)
- **`dist/_headers` byte-identical** — verified with `diff`, so no CSP hash moved
- `wrangler deploy --dry-run` clean, confirming the Worker still bundles with its new import
- `npm audit` — 0 vulnerabilities

One existing e2e fixture needed updating: `labelInName.spec.js` filled a 5-character message, which the new client-side validation correctly rejects before the in-flight state that test is about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)