### PR TITLE
ci: gate merges on one aggregate check instead of four named jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,3 +117,55 @@ jobs:
         run: npx playwright install --with-deps chromium
       - name: Run E2E tests
         run: npm run test:e2e
+
+  # ── The single required check ────────────────────────────────────────────────
+  # main's ruleset used to name Lint / Test / Build / Security individually, so
+  # every new job here had to be added to the ruleset by hand — and a job nobody
+  # remembered to add was simply not enforced, which is a gap that reports green.
+  # This job aggregates them, so the ruleset names one context and adding a job
+  # above is enough to have it gate merges.
+  #
+  # `if: always()` is load-bearing, not defensive. Without it this job inherits
+  # the default `needs` behaviour and is *skipped* when any dependency fails —
+  # and GitHub counts a skipped required check as a passing one. The naive version
+  # of this job therefore inverts the protection it looks like it provides: lint
+  # goes red, the gate is skipped, the ruleset sees success, the PR merges. So it
+  # always runs, and inspects the results itself.
+  #
+  # Deliberately not `needs.*.result != 'success'`: a matrix or conditional job
+  # added later can legitimately report 'skipped', and the failure modes are
+  # enumerated so the reason is visible in the log rather than inferred from an
+  # inequality.
+  #
+  # Scope: `needs` only reaches jobs in this file. Cloudflare's "Workers Builds"
+  # is an external check with no job to depend on, so it stays separately
+  # required. pr-checks.yml cannot join either — it has no `merge_group` trigger,
+  # so in the queue its jobs never report at all.
+  ci:
+    name: ✅ CI
+    runs-on: ubuntu-latest
+    needs: [setup, lint, test, build, security, e2e]
+    if: always()
+    steps:
+      # Always print the results, pass or fail, so a red gate says which job was
+      # responsible without opening the other jobs.
+      - name: Report upstream results
+        run: |
+          echo "setup=${{ needs.setup.result }}"
+          echo "lint=${{ needs.lint.result }}"
+          echo "test=${{ needs.test.result }}"
+          echo "build=${{ needs.build.result }}"
+          echo "security=${{ needs.security.result }}"
+          echo "e2e=${{ needs.e2e.result }}"
+
+      # The condition is a step-level `if:` rather than a shell `if` around
+      # ${{ }}. Both work, but in a `run:` block the expression is text that bash
+      # parses *after* substitution, so a line-wrapped one relies on the expansion
+      # collapsing to valid shell. Here it is unambiguously an expression, and the
+      # step is simply skipped when everything passed.
+      - name: Fail if any upstream job did not succeed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') ||
+          contains(needs.*.result, 'skipped')
+        run: |
+          echo "::error::A CI job did not succeed — see the per-job results above."
+          exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,8 @@
         "tailwindcss": "^4.3.2",
         "vite": "^8.1.3",
         "vite-bundle-analyzer": "^1.3.9",
-        "vitest": "^4.1.10"
+        "vitest": "^4.1.10",
+        "yaml": "^2.9.0"
       },
       "engines": {
         "node": ">=22"
@@ -6833,7 +6834,6 @@
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "tailwindcss": "^4.3.2",
     "vite": "^8.1.3",
     "vite-bundle-analyzer": "^1.3.9",
-    "vitest": "^4.1.10"
+    "vitest": "^4.1.10",
+    "yaml": "^2.9.0"
   },
   "overrides": {
     "@babel/core": "^7.29.1",

--- a/src/__tests__/ciGate.test.js
+++ b/src/__tests__/ciGate.test.js
@@ -1,0 +1,82 @@
+/**
+ * @file ciGate.test.js
+ * @author Aswin
+ * @copyright © 2025 Aswin. All rights reserved.
+ * @description Guards the aggregate required check in .github/workflows/ci.yml.
+ *
+ *   main's ruleset names one status check — "✅ CI" — instead of naming Lint /
+ *   Test / Build / Security individually. That trades a manual ruleset edit per
+ *   new job for a manual `needs:` edit per new job, which is only an improvement
+ *   because a `needs:` list is a file in the repo and can therefore be tested.
+ *   This is that test: add a job to ci.yml without wiring it into the gate and
+ *   this fails, instead of the job silently not gating anything.
+ *
+ *   The `if: always()` assertion below is the important one. Without it the gate
+ *   job is *skipped* when a dependency fails, and GitHub counts a skipped
+ *   required check as a passing one — so the whole mechanism would report green
+ *   on a red build. That is a failure that looks exactly like success from every
+ *   angle except this assertion, which is why it is pinned rather than trusted
+ *   to survive a future edit.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const workflow = parse(readFileSync(resolve(repoRoot, '.github/workflows/ci.yml'), 'utf8'));
+
+/** The aggregate gate, by the id the ruleset's context resolves to. */
+const GATE = 'ci';
+
+describe('CI aggregate gate', () => {
+  it('exists and is the check the ruleset can require by name', () => {
+    expect(workflow.jobs[GATE]).toBeTruthy();
+    // The ruleset matches on the *display name*, not the job id.
+    expect(workflow.jobs[GATE].name).toBe('✅ CI');
+  });
+
+  it('depends on every other job in the workflow', () => {
+    const others = Object.keys(workflow.jobs)
+      .filter(id => id !== GATE)
+      .sort();
+    const needs = [...workflow.jobs[GATE].needs].sort();
+
+    // The whole point of the aggregate: a job that isn't in this list runs on
+    // every PR and blocks nothing, which reads as covered and isn't.
+    expect(needs).toEqual(others);
+  });
+
+  it('runs even when a dependency fails', () => {
+    // Not cosmetic. A gate without this is skipped on upstream failure, and a
+    // skipped required check counts as passed — the gate would pass *because*
+    // the build broke.
+    expect(String(workflow.jobs[GATE].if).trim()).toBe('always()');
+  });
+
+  it('fails on every non-success upstream result', () => {
+    // The failing step is the one that exits non-zero; its `if:` is the condition
+    // that decides whether the gate goes red.
+    const failStep = workflow.jobs[GATE].steps.find(s => /exit 1/.test(s.run ?? ''));
+    expect(failStep, 'no step in the gate can fail the job').toBeTruthy();
+
+    // Collapse the wrapped YAML scalar before matching — how it is line-broken is
+    // formatting, not meaning, and prettier owns that.
+    const condition = String(failStep.if).replace(/\s+/g, ' ');
+
+    // 'skipped' matters as much as 'failure' here: `needs: setup` means one
+    // early failure skips the rest, and a gate that only looked for 'failure'
+    // would wave through a run where nothing but setup even executed.
+    for (const result of ['failure', 'cancelled', 'skipped']) {
+      expect(condition).toContain(`contains(needs.*.result, '${result}')`);
+    }
+  });
+
+  it('still reports inside the merge queue', () => {
+    // A required check that never reports on the merge_group event does not fail
+    // the queue — it stalls it until the timeout, then fails. This trigger is
+    // why pr-checks.yml's jobs cannot join the aggregate.
+    expect(Object.keys(workflow.on)).toContain('merge_group');
+  });
+});


### PR DESCRIPTION
## Why

`main`'s ruleset names 🔍 Lint / 🧪 Test / 🏗️ Build / 🔒 Security **individually**, so every new job in `ci.yml` has to be added to the ruleset by hand. A job nobody remembers to add still runs on every PR and blocks nothing — a coverage gap whose only symptom is a green check.

## What

A `✅ CI` job that depends on every other job in `ci.yml`, so the ruleset can name **one** context and wiring a new job into the gate is enough to make it gate.

### `if: always()` is the load-bearing part

Without it the gate inherits the default `needs` behaviour and is **skipped** when a dependency fails — and GitHub counts a skipped required check as **passing**. The naive version of this job therefore *inverts* the protection it appears to add:

> lint goes red → gate is skipped → ruleset sees success → PR merges

So it always runs and inspects `needs.*.result` itself, treating `'skipped'` as a failure alongside `'failure'` and `'cancelled'` — with `needs: setup`, one early failure skips everything downstream, and a gate watching only for `'failure'` would wave through a run where nothing but `setup` executed.

The condition is a step-level `if:` rather than a shell `if` wrapped around `${{ }}`: inside a `run:` block the expression is text bash parses *after* substitution, so a line-wrapped one would depend on the expansion collapsing to valid shell.

## This relocates the manual step rather than removing it

A new job still needs adding to `needs:`. The gain is that the list now lives in the repo, so it can be **enforced by a test** — `src/__tests__/ciGate.test.js`, five assertions covering drift, `always()`, the non-success branches, the display name the ruleset matches on, and the `merge_group` trigger. Each was mutation-tested and fails only its own mutation.

## Scope: five required checks → two, not one

| Check | Can it join? |
| --- | --- |
| Lint, Test, Build, Security | ✅ same workflow file |
| **Workers Builds** | ❌ external check, no job to depend on — **stays separately required** |
| Lighthouse, Bundle Size, Dependency Review | ❌ `pr-checks.yml` has no `merge_group` trigger, so they never report in the queue |

`needs:` only reaches jobs in the same file, which is the ceiling here.

## Two consequences worth knowing

1. **🎭 E2E and 📦 Setup become required**, being in `ci.yml`. E2E is 15/15 green historically and caught a real regression in #192, but it adds ~1m to the critical path and a flake now blocks the queue.
2. **The ruleset swap is a separate, ordered step.** Requiring a context that has never reported deadlocks the merge queue for 60 minutes and then fails. This PR only adds the job; once `✅ CI` is observed reporting here, the ruleset can be pointed at it.

## ⚠️ Merging this PR alone changes no enforcement

The ruleset still names the four jobs. After merge, ruleset 6505932's required checks should become `✅ CI` + `Workers Builds: aswin-portfolio`. I have not touched the ruleset.

## Verification

- 338 unit tests / 20 files (was 333/19), 31 e2e, lint, `format:check`, copyright strict, build
- `npm audit` → 0 vulnerabilities
- All 5 guard assertions mutation-tested — each kills its own mutation and no other
- Shell-verified the guard both ways: all-success → exit 0, any failure → exit 1
- `yaml` declared as a devDependency (`^2.9.0`, matching the repo's caret convention); the guard parses the workflow and it was previously only transitive via vite/lint-staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)